### PR TITLE
docs: add npm, license, node, and tmux badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ReevesAgents
 
-Version: `1.2.0`
+[![npm version](https://img.shields.io/npm/v/reevesagents?color=blue&label=npm)](https://www.npmjs.com/package/reevesagents)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
+[![Node.js ≥ 20.19](https://img.shields.io/badge/node-%3E%3D20.19-brightgreen)](https://nodejs.org)
+[![tmux ≥ 3.0](https://img.shields.io/badge/tmux-%3E%3D3.0-yellow)](https://github.com/tmux/tmux)
 
 GitHub: https://github.com/mertkayacs/reevesagents
 


### PR DESCRIPTION
Closes #4

## Summary

- Adds four shields.io badges at the top of the README: npm version, Apache-2.0 license, Node.js ≥ 20.19, and tmux ≥ 3.0
- Replaces the plain-text `Version: 1.2.0` line with a live npm badge that always reflects the latest published version
- No content or documentation was changed — purely visual improvement for the repo landing page