### PR TITLE
fix: tmux launcher index-in-use + registry/tty robustness + codex effort

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,9 +93,17 @@ function tmuxAttachCommand(session: string, windowId: string): string {
   return `tmux select-window -t ${quoteShell(`${session}:${windowId}`)} && tmux attach -t ${quoteShell(session)}`
 }
 
+// tmux resolves a bare target against both session and window names, with prefix matching, so a
+// leftover "reeves-*" session or the equally-named TUI window hijacks it: the wrong session, or an
+// index-1 collision that fails "create window failed: index 1 in use". "=" forces an exact session
+// match; a trailing ":" makes new-window append at the next free index instead of a pinned one.
+function exactSession(session: string): string {
+  return `=${session}`
+}
+
 function tmuxSessionExists(session: string): boolean {
   try {
-    execFileSync('tmux', ['has-session', '-t', session], { stdio: 'ignore' })
+    execFileSync('tmux', ['has-session', '-t', exactSession(session)], { stdio: 'ignore' })
     return true
   } catch {
     return false
@@ -104,7 +112,7 @@ function tmuxSessionExists(session: string): boolean {
 
 function tmuxWindowIds(session: string): string[] {
   try {
-    return execFileSync('tmux', ['list-windows', '-t', session, '-F', '#{window_id}'], { encoding: 'utf8' })
+    return execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}'], { encoding: 'utf8' })
       .split('\n')
       .map(line => line.trim())
       .filter(Boolean)
@@ -120,7 +128,7 @@ interface TmuxWindowInfo {
 
 function tmuxWindowByName(session: string, name: string): TmuxWindowInfo | null {
   try {
-    const rows = execFileSync('tmux', ['list-windows', '-t', session, '-F', '#{window_id}\t#{window_name}\t#{pane_current_command}'], { encoding: 'utf8' })
+    const rows = execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}\t#{window_name}\t#{pane_current_command}'], { encoding: 'utf8' })
       .split('\n')
       .map(line => line.trim())
       .filter(Boolean)
@@ -149,19 +157,12 @@ function clearTuiSessionExcept(session: string, keepWindowId: string): void {
   }
 }
 
+export function tuiNewWindowArgs(session: string, window: string, command: string): string[] {
+  return ['new-window', '-d', '-P', '-F', '#{window_id}', '-t', `${exactSession(session)}:`, '-n', window, command]
+}
+
 function createTuiWindow(session: string, window: string, command: string): string {
-  return execFileSync('tmux', [
-    'new-window',
-    '-d',
-    '-P',
-    '-F',
-    '#{window_id}',
-    '-t',
-    session,
-    '-n',
-    window,
-    command,
-  ], { encoding: 'utf8' }).trim()
+  return execFileSync('tmux', tuiNewWindowArgs(session, window, command), { encoding: 'utf8' }).trim()
 }
 
 function openTuiSession(command: string): void {
@@ -182,7 +183,7 @@ function openTuiSession(command: string): void {
     : createTuiWindow(session, window, command)
   execFileSync('tmux', ['select-window', '-t', windowId], { stdio: 'ignore' })
   clearTuiSessionExcept(session, windowId)
-  execFileSync('tmux', ['attach', '-t', session], { stdio: 'inherit' })
+  execFileSync('tmux', ['attach', '-t', exactSession(session)], { stdio: 'inherit' })
 }
 
 function openTarget(id: string): void {
@@ -883,6 +884,10 @@ function runCli(): void {
         process.stderr.write(`tmux launch error: ${err instanceof Error ? err.message : String(err)}\n`)
         process.exit(1)
       }
+    }
+    if (!process.stdout.isTTY) {
+      process.stderr.write('reevesagents requires an interactive terminal. Run it in a terminal, or use a subcommand like "reevesagents doctor".\n')
+      process.exit(1)
     }
     process.on('SIGTERM', () => process.exit(0))
     if (process.stdout.isTTY) process.stdout.write('\x1b[2J\x1b[H')

--- a/src/core/provider-registry.ts
+++ b/src/core/provider-registry.ts
@@ -108,9 +108,14 @@ export const PROVIDER_REGISTRY: Record<Provider, ProviderDef> = {
     helpRequirements: [
       { feature: 'skip permissions', tokens: ['--dangerously-bypass-approvals-and-sandbox'] },
     ],
-    buildArgs: ({ permissions, model }) => {
+    buildArgs: ({ permissions, model, effort }) => {
       const args: string[] = []
       if (permissions === 'skip') args.push('--dangerously-bypass-approvals-and-sandbox')
+      // codex has no --effort flag; reasoning effort is a config value whose scale tops out at
+      // xhigh, so map reeves "max" down to xhigh.
+      if (effort && effort !== 'default') {
+        args.push('-c', `model_reasoning_effort="${effort === 'max' ? 'xhigh' : effort}"`)
+      }
       if (model) args.push('--model', model)
       return args
     },

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -233,14 +233,13 @@ function writeRunUnlocked(run: RunRecord): string {
 }
 
 function readRunUnlocked(runId: string): RunRecord {
-  let raw: string
   try {
-    raw = readFileSync(runPath(runId), 'utf-8')
+    const raw = readFileSync(runPath(runId), 'utf-8')
+    // A missing or corrupt run reads as "not found", not a raw fs/parse error that leaks the path.
+    return normalizeRun(JSON.parse(raw) as Record<string, unknown>)
   } catch {
-    // A missing run reads as "not found", not a raw fs error that leaks the path.
     throw new Error(`Run not found: ${runId}`)
   }
-  return normalizeRun(JSON.parse(raw) as Record<string, unknown>)
 }
 
 function writeAgentUnlocked(agent: AgentRecord): string {
@@ -256,7 +255,11 @@ function writeRunHistoryUnlocked(record: RunHistoryRecord): string {
 }
 
 function readAgentUnlocked(runId: string, agentId: string): AgentRecord {
-  return normalizeAgent(JSON.parse(readFileSync(agentPath(runId, agentId), 'utf-8')) as Record<string, unknown>)
+  try {
+    return normalizeAgent(JSON.parse(readFileSync(agentPath(runId, agentId), 'utf-8')) as Record<string, unknown>)
+  } catch {
+    throw new Error(`Agent not found: ${agentId}`)
+  }
 }
 
 export function writeRun(run: RunRecord): string {

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -206,7 +206,7 @@ function pickReevesAnchor(driver: RuntimeDriver): { sessionName: string; windowI
   } catch { /* session may already exist */ }
   let ids = readDisplayIds(driver, `${fallbackName}:reeves`)
   if (!ids) {
-    try { driver.tmux(['new-window', '-d', '-t', fallbackName, '-n', 'reeves']) } catch { /* anchor may already exist */ }
+    try { driver.tmux(['new-window', '-d', '-t', `${fallbackName}:`, '-n', 'reeves']) } catch { /* anchor may already exist */ }
     ids = readDisplayIds(driver, `${fallbackName}:reeves`)
   }
   return { sessionName: fallbackName, windowId: ids?.windowId ?? '', paneId: ids?.paneId ?? '' }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -204,10 +204,10 @@ function pickReevesAnchor(driver: RuntimeDriver): { sessionName: string; windowI
   try {
     driver.tmux(['new-session', '-d', '-s', fallbackName, '-n', 'reeves'])
   } catch { /* session may already exist */ }
-  let ids = readDisplayIds(driver, `${fallbackName}:reeves`)
+  let ids = readDisplayIds(driver, `=${fallbackName}:reeves`)
   if (!ids) {
     try { driver.tmux(['new-window', '-d', '-t', `${fallbackName}:`, '-n', 'reeves']) } catch { /* anchor may already exist */ }
-    ids = readDisplayIds(driver, `${fallbackName}:reeves`)
+    ids = readDisplayIds(driver, `=${fallbackName}:reeves`)
   }
   return { sessionName: fallbackName, windowId: ids?.windowId ?? '', paneId: ids?.paneId ?? '' }
 }

--- a/test/cli-launcher.test.ts
+++ b/test/cli-launcher.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { tuiNewWindowArgs } from '../src/cli.js'
+
+// Regression guard for the "index 1 in use" launch failure: the app names the TUI session AND its
+// window "reeves", and every leftover reeves-* session also has an index-1 window named "reeves".
+// A bare `new-window -t reeves` resolves to that window and pins index 1; the exact-session + trailing
+// colon form forces tmux to append at the next free index in the app-owned session only.
+describe('tui launcher tmux target', () => {
+  it('appends via an exact-session target, never a bare or prefix-matchable name', () => {
+    const args = tuiNewWindowArgs('reeves', 'reeves', 'node cli.js')
+    const target = args[args.indexOf('-t') + 1]
+    expect(target).toBe('=reeves:')
+    expect(target).not.toBe('reeves')
+    expect(args).toEqual([
+      'new-window', '-d', '-P', '-F', '#{window_id}', '-t', '=reeves:', '-n', 'reeves', 'node cli.js',
+    ])
+  })
+})

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -59,6 +59,24 @@ describe('providers', () => {
       expect(cmd).toEqual(['codex'])
     })
 
+    it('codex maps effort to a model_reasoning_effort config override (no --effort flag exists)', () => {
+      const cmd = buildCommand({ provider: 'codex', permissions: 'ask', model: '', effort: 'low' })
+      expect(cmd).not.toContain('--effort')
+      const i = cmd.indexOf('-c')
+      expect(i).toBeGreaterThanOrEqual(0)
+      expect(cmd[i + 1]).toBe('model_reasoning_effort="low"')
+    })
+
+    it('codex clamps effort "max" to codex xhigh', () => {
+      const cmd = buildCommand({ provider: 'codex', permissions: 'ask', model: '', effort: 'max' })
+      expect(cmd).toContain('model_reasoning_effort="xhigh"')
+    })
+
+    it('codex with default effort adds no reasoning override', () => {
+      const cmd = buildCommand({ provider: 'codex', permissions: 'ask', model: '', effort: 'default' })
+      expect(cmd).toEqual(['codex'])
+    })
+
     it('opencode with skip permissions does not add undocumented skip flags', () => {
       const opts: BuildCommandOptions = { provider: 'opencode', permissions: 'skip', model: '' }
       const cmd = buildCommand(opts)

--- a/test/runs-state.test.ts
+++ b/test/runs-state.test.ts
@@ -357,4 +357,38 @@ describe('v1 run state', () => {
       expect(listRunHistory().map(record => record.id)).toEqual(['finished'])
     })
   })
+
+  it('throws "Run not found" when run.json is corrupt (not SyntaxError)', async () => {
+    const { writeRun, readRun, runPath } = await import('../src/core/runs.js')
+    const run = makeRun('corrupt-run')
+    writeRun(run)
+
+    const path = runPath('corrupt-run')
+    writeFileSync(path, '{ broken', 'utf-8')
+
+    expect(() => readRun('corrupt-run')).toThrow(/Run not found/)
+    expect(() => readRun('corrupt-run')).not.toThrow(SyntaxError)
+  })
+
+  it('throws "Agent not found" when agent.json is corrupt (not SyntaxError)', async () => {
+    const { writeRun, writeAgent, readAgent, agentPath } = await import('../src/core/runs.js')
+    const run = makeRun('agent-test')
+    const agent = makeAgent('corrupt-agent', 'agent-test')
+    writeRun(run)
+    writeAgent(agent)
+
+    const path = agentPath('agent-test', 'corrupt-agent')
+    writeFileSync(path, '{ broken', 'utf-8')
+
+    expect(() => readAgent('agent-test', 'corrupt-agent')).toThrow(/Agent not found/)
+    expect(() => readAgent('agent-test', 'corrupt-agent')).not.toThrow(SyntaxError)
+  })
+
+  it('throws "Agent not found" when agent.json is missing', async () => {
+    const { writeRun, readAgent } = await import('../src/core/runs.js')
+    const run = makeRun('agent-missing-test')
+    writeRun(run)
+
+    expect(() => readAgent('agent-missing-test', 'does-not-exist')).toThrow(/Agent not found/)
+  })
 })

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -209,4 +209,55 @@ describe('agent-run runtime', () => {
       { args: ['kill-session', '-t', result.run.tmux_session] },
     ]))
   })
+
+  it('uses colon-delimited target when creating reeves anchor window (regression for issue #11)', async () => {
+    class FakeDriverForcingAnchorFallback implements RuntimeDriver {
+      calls: Array<{ args: string[], input?: string }> = []
+      delays: number[] = []
+      nextWindow = 1
+      captureOutput = '[31mready[0m sk-ant-api03-abcdefghij1234567890abcdef'
+      displayMessageCalls = 0
+
+      tmux(args: string[], input?: string): string {
+        this.calls.push(input === undefined ? { args } : { args, input })
+        if (args[0] === 'display-message') {
+          this.displayMessageCalls++
+          if (this.displayMessageCalls === 1) return ''
+          return '@0 %0'
+        }
+        if (args[0] === 'new-window') {
+          const id = this.nextWindow++
+          return `@${id} %${id}`
+        }
+        if (args[0] === 'capture-pane') return this.captureOutput
+        return ''
+      }
+
+      delay(fn: () => void, ms: number): void {
+        this.delays.push(ms)
+        fn()
+      }
+    }
+
+    const driver = new FakeDriverForcingAnchorFallback()
+    const { startRun } = await import('../src/core/runtime.js')
+
+    startRun({
+      name: 'test-anchor-format',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'test', nickname: 'test' },
+    }, { driver, available })
+
+    const anchorWindowCalls = driver.calls.filter(call =>
+      call.args[0] === 'new-window' && !call.args.includes('-P')
+    )
+
+    expect(anchorWindowCalls.length).toBeGreaterThan(0)
+
+    const anchorCall = anchorWindowCalls[0]!
+    const targetIndex = anchorCall.args.indexOf('-t')
+    const targetValue = anchorCall.args[targetIndex + 1]
+
+    expect(targetValue).toBe('reeves:')
+  })
 })


### PR DESCRIPTION
## What

Fixes the tmux launcher crash (`reevesagents` → `create window failed: index 1 in use`) plus four other bugs found in an end-to-end audit, and two more surfaced by an independent Codex real-CLI smoke test.

Closes #11
Closes #12

## Bugs fixed

**tmux launcher (the reported crash + a data-loss variant).** Typing `reevesagents` with no args passed a bare `reeves` target to tmux. tmux resolves a bare name against window names and prefix-matches sessions, so leftover `reeves-*` sessions caused `index 1 in use`, and with a single leftover session the reuse path could `kill-window` / clear windows in that unrelated session. Now targets the app session exactly (`=reeves`) and appends with a trailing colon (`=reeves:`), matching what `createAgentWindow` already did. Same class fixed in `pickReevesAnchor`.

**registry robustness.** `readRunUnlocked` parsed JSON outside its try/catch and `readAgentUnlocked` had none, so a corrupt or missing run/agent file threw a raw `SyntaxError` / `ENOENT` instead of the normalized "not found".

**non-tty TUI.** `renderTui()` ran on a non-TTY (`reevesagents | cat`, CI, `REEVES_NO_TMUX_WRAPPER=1` piped) and crashed in Ink raw mode. Now prints a clear message and exits non-zero.

**codex effort.** `--effort` was silently dropped for the codex provider (codex has no `--effort` flag). Now mapped to codex's `-c model_reasoning_effort=` config override (`max` clamps to `xhigh`).

## Testing

- 689 unit tests green (5 new regression tests across the launcher, registry, and codex effort), plus typecheck, lint, build.
- Reproduced the tmux failure and verified the fix at the tmux level: `=reeves:` appends where bare `reeves` collided with `index 1 in use`.
- An independent Codex agent ran a real spawn through the built binary with no `index 1 in use`, and the pre-existing `reeves-*` sessions were left intact.

## Notes

Effort is now applied for `cc` and `codex`. Other providers still ignore it because their CLIs differ; tracked in #12 as a follow-up.
