### PR TITLE
fix: tmux launcher index-in-use + registry/tty robustness (rebased on v1.5.0)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,9 +95,17 @@ function tmuxAttachCommand(session: string, windowId: string): string {
   return `tmux select-window -t ${quoteShell(`${session}:${windowId}`)} && tmux attach -t ${quoteShell(session)}`
 }
 
+// tmux resolves a bare target against both session and window names, with prefix matching, so a
+// leftover "reeves-*" session or the equally-named TUI window hijacks it: the wrong session, or an
+// index-1 collision that fails "create window failed: index 1 in use". "=" forces an exact session
+// match; a trailing ":" makes new-window append at the next free index instead of a pinned one.
+function exactSession(session: string): string {
+  return `=${session}`
+}
+
 function tmuxSessionExists(session: string): boolean {
   try {
-    execFileSync('tmux', ['has-session', '-t', session], { stdio: 'ignore' })
+    execFileSync('tmux', ['has-session', '-t', exactSession(session)], { stdio: 'ignore' })
     return true
   } catch {
     return false
@@ -106,7 +114,7 @@ function tmuxSessionExists(session: string): boolean {
 
 function tmuxWindowIds(session: string): string[] {
   try {
-    return execFileSync('tmux', ['list-windows', '-t', session, '-F', '#{window_id}'], { encoding: 'utf8' })
+    return execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}'], { encoding: 'utf8' })
       .split('\n')
       .map(line => line.trim())
       .filter(Boolean)
@@ -122,7 +130,7 @@ interface TmuxWindowInfo {
 
 function tmuxWindowByName(session: string, name: string): TmuxWindowInfo | null {
   try {
-    const rows = execFileSync('tmux', ['list-windows', '-t', session, '-F', '#{window_id}\t#{window_name}\t#{pane_current_command}'], { encoding: 'utf8' })
+    const rows = execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}\t#{window_name}\t#{pane_current_command}'], { encoding: 'utf8' })
       .split('\n')
       .map(line => line.trim())
       .filter(Boolean)
@@ -151,19 +159,12 @@ function clearTuiSessionExcept(session: string, keepWindowId: string): void {
   }
 }
 
+export function tuiNewWindowArgs(session: string, window: string, command: string): string[] {
+  return ['new-window', '-d', '-P', '-F', '#{window_id}', '-t', `${exactSession(session)}:`, '-n', window, command]
+}
+
 function createTuiWindow(session: string, window: string, command: string): string {
-  return execFileSync('tmux', [
-    'new-window',
-    '-d',
-    '-P',
-    '-F',
-    '#{window_id}',
-    '-t',
-    session,
-    '-n',
-    window,
-    command,
-  ], { encoding: 'utf8' }).trim()
+  return execFileSync('tmux', tuiNewWindowArgs(session, window, command), { encoding: 'utf8' }).trim()
 }
 
 function openTuiSession(command: string): void {
@@ -184,7 +185,7 @@ function openTuiSession(command: string): void {
     : createTuiWindow(session, window, command)
   execFileSync('tmux', ['select-window', '-t', windowId], { stdio: 'ignore' })
   clearTuiSessionExcept(session, windowId)
-  execFileSync('tmux', ['attach', '-t', session], { stdio: 'inherit' })
+  execFileSync('tmux', ['attach', '-t', exactSession(session)], { stdio: 'inherit' })
 }
 
 function openTarget(id: string): void {
@@ -1043,6 +1044,10 @@ function runCli(): void {
         process.stderr.write(`tmux launch error: ${err instanceof Error ? err.message : String(err)}\n`)
         process.exit(1)
       }
+    }
+    if (!process.stdout.isTTY) {
+      process.stderr.write('reevesagents requires an interactive terminal. Run it in a terminal, or use a subcommand like "reevesagents doctor".\n')
+      process.exit(1)
     }
     process.on('SIGTERM', () => process.exit(0))
     if (process.stdout.isTTY) process.stdout.write('\x1b[2J\x1b[H')

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -233,14 +233,13 @@ function writeRunUnlocked(run: RunRecord): string {
 }
 
 function readRunUnlocked(runId: string): RunRecord {
-  let raw: string
   try {
-    raw = readFileSync(runPath(runId), 'utf-8')
+    const raw = readFileSync(runPath(runId), 'utf-8')
+    // A missing or corrupt run reads as "not found", not a raw fs/parse error that leaks the path.
+    return normalizeRun(JSON.parse(raw) as Record<string, unknown>)
   } catch {
-    // A missing run reads as "not found", not a raw fs error that leaks the path.
     throw new Error(`Run not found: ${runId}`)
   }
-  return normalizeRun(JSON.parse(raw) as Record<string, unknown>)
 }
 
 function writeAgentUnlocked(agent: AgentRecord): string {
@@ -256,7 +255,11 @@ function writeRunHistoryUnlocked(record: RunHistoryRecord): string {
 }
 
 function readAgentUnlocked(runId: string, agentId: string): AgentRecord {
-  return normalizeAgent(JSON.parse(readFileSync(agentPath(runId, agentId), 'utf-8')) as Record<string, unknown>)
+  try {
+    return normalizeAgent(JSON.parse(readFileSync(agentPath(runId, agentId), 'utf-8')) as Record<string, unknown>)
+  } catch {
+    throw new Error(`Agent not found: ${agentId}`)
+  }
 }
 
 export function writeRun(run: RunRecord): string {

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -207,10 +207,10 @@ function pickReevesAnchor(driver: RuntimeDriver): { sessionName: string; windowI
   try {
     driver.tmux(['new-session', '-d', '-s', fallbackName, '-n', 'reeves'])
   } catch { /* session may already exist */ }
-  let ids = readDisplayIds(driver, `${fallbackName}:reeves`)
+  let ids = readDisplayIds(driver, `=${fallbackName}:reeves`)
   if (!ids) {
-    try { driver.tmux(['new-window', '-d', '-t', fallbackName, '-n', 'reeves']) } catch { /* anchor may already exist */ }
-    ids = readDisplayIds(driver, `${fallbackName}:reeves`)
+    try { driver.tmux(['new-window', '-d', '-t', `${fallbackName}:`, '-n', 'reeves']) } catch { /* anchor may already exist */ }
+    ids = readDisplayIds(driver, `=${fallbackName}:reeves`)
   }
   return { sessionName: fallbackName, windowId: ids?.windowId ?? '', paneId: ids?.paneId ?? '' }
 }

--- a/test/cli-launcher.test.ts
+++ b/test/cli-launcher.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { tuiNewWindowArgs } from '../src/cli.js'
+
+// Regression guard for the "index 1 in use" launch failure: the app names the TUI session AND its
+// window "reeves", and every leftover reeves-* session also has an index-1 window named "reeves".
+// A bare `new-window -t reeves` resolves to that window and pins index 1; the exact-session + trailing
+// colon form forces tmux to append at the next free index in the app-owned session only.
+describe('tui launcher tmux target', () => {
+  it('appends via an exact-session target, never a bare or prefix-matchable name', () => {
+    const args = tuiNewWindowArgs('reeves', 'reeves', 'node cli.js')
+    const target = args[args.indexOf('-t') + 1]
+    expect(target).toBe('=reeves:')
+    expect(target).not.toBe('reeves')
+    expect(args).toEqual([
+      'new-window', '-d', '-P', '-F', '#{window_id}', '-t', '=reeves:', '-n', 'reeves', 'node cli.js',
+    ])
+  })
+})

--- a/test/runs-state.test.ts
+++ b/test/runs-state.test.ts
@@ -357,4 +357,27 @@ describe('v1 run state', () => {
       expect(listRunHistory().map(record => record.id)).toEqual(['finished'])
     })
   })
+
+  describe('corrupt or missing registry files', () => {
+    it('readRun returns a not-found error, not a raw SyntaxError, on corrupt run.json', async () => {
+      const { writeRun, readRun, runPath } = await import('../src/core/runs.js')
+      writeRun(makeRun('corrupt-run'))
+      writeFileSync(runPath('corrupt-run'), '{ broken', 'utf-8')
+      expect(() => readRun('corrupt-run')).toThrow(/Run not found/)
+    })
+
+    it('readAgent returns a not-found error, not a raw SyntaxError, on corrupt agent json', async () => {
+      const { writeRun, writeAgent, readAgent, agentPath } = await import('../src/core/runs.js')
+      writeRun(makeRun('run-a'))
+      writeAgent(makeAgent('agent-a', 'run-a'))
+      writeFileSync(agentPath('run-a', 'agent-a'), '{ broken', 'utf-8')
+      expect(() => readAgent('run-a', 'agent-a')).toThrow(/Agent not found/)
+    })
+
+    it('readAgent returns a not-found error for a missing agent file', async () => {
+      const { writeRun, readAgent } = await import('../src/core/runs.js')
+      writeRun(makeRun('run-b'))
+      expect(() => readAgent('run-b', 'nope')).toThrow(/Agent not found/)
+    })
+  })
 })

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -209,4 +209,32 @@ describe('agent-run runtime', () => {
       { args: ['kill-session', '-t', result.run.tmux_session] },
     ]))
   })
+
+  it('creates the reeves anchor window with an append target, not a bare name', async () => {
+    // When display-message is unparseable, readDisplayIds returns null and pickReevesAnchor creates
+    // the anchor window explicitly. That new-window must append (reeves:), not target a bare "reeves"
+    // that would collide with the same-named window and fail "index 1 in use".
+    class NoDisplayDriver extends FakeDriver {
+      tmux(args: string[], input?: string): string {
+        if (args[0] === 'display-message') { this.calls.push({ args }); return '' }
+        return super.tmux(args, input)
+      }
+    }
+    const driver = new NoDisplayDriver()
+    const { startRun } = await import('../src/core/runtime.js')
+    try {
+      startRun({
+        name: 'anchor',
+        working_dir: '/tmp',
+        root: { provider: 'codex', model: '', task: '', nickname: 'a' },
+      }, { driver, available })
+    } catch { /* the anchor new-window is recorded before any later failure */ }
+    const anchor = driver.calls.find(call =>
+      call.args[0] === 'new-window' && !call.args.includes('-P') &&
+      call.args[call.args.indexOf('-n') + 1] === 'reeves')
+    expect(anchor, 'anchor new-window call').toBeTruthy()
+    const target = anchor!.args[anchor!.args.indexOf('-t') + 1]
+    expect(target).toBe('reeves:')
+    expect(target).not.toBe('reeves')
+  })
 })


### PR DESCRIPTION
## What

Fixes the tmux launcher crash (`reevesagents` → `create window failed: index 1 in use`) plus registry and non-TTY robustness bugs found in an end-to-end audit, and the same-class anchor-path variant.

Closes #11
Closes #12

## Bugs fixed

**tmux launcher (the reported crash + a data-loss variant).** Typing `reevesagents` with no args passed a bare `reeves` target to tmux. tmux resolves a bare name against window names and prefix-matches sessions, so leftover `reeves-*` sessions caused `index 1 in use`, and with a single leftover session the reuse path could `kill-window` / clear windows in that unrelated session. Now targets the app session exactly (`=reeves`) and appends with a trailing colon (`=reeves:`), matching what `createAgentWindow` already did.

**anchor targets.** `pickReevesAnchor` used the same bare-`reeves` pattern for its fallback `new-window` and its id resolution; now `reeves:` append and exact `=reeves:reeves`.

**registry robustness.** `readRunUnlocked` parsed JSON outside its try/catch and `readAgentUnlocked` had none, so a corrupt or missing run/agent file threw a raw `SyntaxError` / `ENOENT` instead of the normalized "not found".

**non-tty TUI.** `renderTui()` ran on a non-TTY (`reevesagents | cat`, CI, `REEVES_NO_TMUX_WRAPPER=1` piped) and crashed in Ink raw mode. Now prints a clear message and exits non-zero.

## Not included

The codex `--effort` mapping from #12 was already fixed on master in `7c1b4fa`, so this PR does not touch it.

## Testing

- 713 unit tests green, including 5 new regression tests (launcher target, anchor target, corrupt run/agent json), plus typecheck, lint, build.
- Reproduced the tmux failure and verified the fix at the tmux level: `=reeves:` appends where bare `reeves` collided with `index 1 in use`.
- An independent Codex agent ran a real spawn earlier with no `index 1 in use`, and the pre-existing `reeves-*` sessions were left intact.
