### PR TITLE
feat(mcp): one-command setup with OpenCode auto-attach and accurate status

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Discovery, approvals, agent control, config, and cleanup:
 - `approve <approval-id> [note]`: Resolve an approval request as approved.
 - `deny <approval-id> [note]`: Resolve an approval request as denied.
 - `hosts`: List the agent CLIs on this machine and show which ones ReevesAgents is connected to.
-- `attach [cli]`: Connect ReevesAgents to one agent CLI, or to every installed one when no name is given. Runs that CLI's own `mcp add`.
+- `attach [cli]`: Connect ReevesAgents to one agent CLI, or to every installed one when no name is given. Runs that CLI's own `mcp add` (or edits `opencode.json` for OpenCode). For a one-shot "set everything up" (attach every host and install the skill), use `reevesagents setup --attach`.
 - `detach <cli>`: Disconnect ReevesAgents from one agent CLI. Runs that CLI's own `mcp remove`.
 - `skills [action]`: Install the ReevesAgents skill (a `SKILL.md`) so skill-aware CLIs (Claude Code, Codex, Kimi, OpenCode) learn to drive ReevesAgents on their own. Actions: `status` (default), `install`, `remove`. Key flags: `--json`.
 - `mcp`: Start the Agent control MCP server over stdio. Not run by hand; the CLI you connect it to runs it.
@@ -324,8 +324,15 @@ codex, kimi, qwen, opencode, hermes) and lets you attach, detach, or attach all.
 Attaching runs that CLI's own `mcp add` command (for example
 `claude mcp add reevesagents -- reevesagents mcp`); detaching runs the matching
 remove. ReevesAgents only calls each CLI's own command and never edits provider
-config files by hand. OpenCode is the exception: its `mcp add` is interactive
-and has no remove, so the screen marks it attach-by-hand.
+config files by hand. OpenCode is the exception: it has no scriptable `mcp add`
+for a local server, so ReevesAgents attaches it by writing the `reevesagents`
+entry into its `~/.config/opencode/opencode.json` directly (and removes just that
+entry on detach).
+
+Codex sandboxes MCP tool calls by default, which blocks reevesagents from
+launching agents in tmux. Run Codex with full access when driving agents, for
+example `codex --sandbox danger-full-access`, or add a profile that sets
+`sandbox_mode = "danger-full-access"` and run `codex --profile <name>`.
 
 Once a CLI is attached, it has the Agent Control tools whenever it starts.
 Installing it is your explicit choice, and that choice is the consent. One run

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -108,8 +108,12 @@ hermes. For each one you can attach, detach, or attach all.
   `--args` form for hermes. reeves only calls the CLI's own command and never
   edits provider config files by hand.
 - Detach runs the matching remove.
-- OpenCode is the exception: its `mcp add` is interactive and it has no remove
-  subcommand, so the screen marks it attach-by-hand rather than driving it.
+- OpenCode is the exception: it has no scriptable `mcp add` for a local server, so
+  reeves attaches it by writing the `reevesagents` entry into
+  `~/.config/opencode/opencode.json` directly, and detach removes only that entry.
+- Codex sandboxes MCP tool calls by default, which blocks reevesagents from
+  spawning agents in tmux; run Codex with `--sandbox danger-full-access` (or a
+  profile that sets it) when driving agents.
 
 Installing it is your explicit choice. That choice is the consent. After that,
 the CLI you attached has the reeves tools whenever it starts, and nothing else

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -753,8 +753,11 @@ program
         return
       }
 
-      console.log('\nConnecting...')
+      console.log('\nSetting up...')
       const result = await runOnboarding()
+      if (result.skills.some(skill => skill.ok)) {
+        console.log('  ok  skill      installed for skill-aware CLIs (Claude, Codex, Kimi, OpenCode)')
+      }
       for (const attached of result.attached) {
         console.log(`  ${(attached.ok ? 'ok' : '--').padEnd(3)} ${attached.key.padEnd(10)} ${attached.message}`)
       }

--- a/src/core/onboard.ts
+++ b/src/core/onboard.ts
@@ -14,6 +14,7 @@ import {
   type HostStatus,
   type VerifyResult,
 } from '../mcp/installer.js'
+import { installSkills, type SkillActionResult } from './skills.js'
 import type { Provider } from './types.js'
 
 export interface OnboardingState {
@@ -50,15 +51,18 @@ export function buildOnboardingState(): OnboardingState {
 export interface OnboardingResult {
   attached: AttachResult[]
   verify: VerifyResult | null
+  skills: SkillActionResult[]
 }
 
-// The consented setup action: connect every installed drivable host, then verify
-// the server launches. Idempotent, because attachAll skips already-attached
-// hosts, so re-running is safe.
+// The consented setup action: install the skill for skill-aware CLIs, connect
+// every installed drivable host over MCP, then verify the server launches. This is
+// the one-command "make it work everywhere" path. Idempotent: installSkills
+// overwrites and attachAll skips already-attached hosts, so re-running is safe.
 export async function runOnboarding(): Promise<OnboardingResult> {
+  const skills = installSkills()
   const attached = attachAll()
   const verify = attached.some(result => result.ok) ? await verifyServerLaunch() : null
-  return { attached, verify }
+  return { attached, verify, skills }
 }
 
 // A copy-paste instruction to try in a freshly connected host CLI, naming a provider

--- a/src/mcp/installer.ts
+++ b/src/mcp/installer.ts
@@ -6,7 +6,9 @@
 // own launch environment does not carry the user's interactive PATH.
 
 import { execFileSync } from 'node:child_process'
-import { realpathSync } from 'node:fs'
+import { realpathSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
 import { PROVIDER_REGISTRY } from '../core/provider-registry.js'
 import type { Provider } from '../core/types.js'
 
@@ -14,10 +16,72 @@ const SERVER_NAME = 'reevesagents'
 const SERVER_BIN = 'reevesagents'
 const SERVER_ARG = 'mcp'
 const MGMT_TIMEOUT_MS = 15_000
-// Shorter cap for the read-only `mcp list` status probe so hosts/setup do not hang
-// for the full management timeout per slow host.
-const STATUS_TIMEOUT_MS = 5_000
+// Cap for the read-only `mcp list` status probe. Kept generous because some hosts
+// (Claude Code) health-check every configured MCP server when listing, so with a
+// handful of slow remote servers the list can take well over 5s; too short a cap
+// made an attached reevesagents read as "detached".
+const STATUS_TIMEOUT_MS = 20_000
 const VERIFY_TIMEOUT_MS = 20_000
+
+// OpenCode has no scriptable `mcp add` for a local (stdio) server, so we attach it
+// by editing its global config JSON directly instead of shelling out to the CLI.
+function opencodeConfigPath(): string {
+  // REEVES_HOME overrides the real home for tests/sandboxes, matching the skills
+  // installer; unset in normal use so it resolves to ~/.config/opencode.
+  const base = process.env.REEVES_HOME || homedir()
+  const dir = join(base, '.config', 'opencode')
+  const jsonc = join(dir, 'opencode.jsonc')
+  const json = join(dir, 'opencode.json')
+  if (existsSync(json)) return json
+  if (existsSync(jsonc)) return jsonc
+  return json
+}
+
+// Read OpenCode's config as an object. Returns {} when the file is missing.
+// Throws (caught by callers) when the file exists but is not strict JSON, e.g. it
+// carries JSONC comments; we refuse to rewrite what we cannot parse safely.
+function readOpencodeConfig(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {}
+  const raw = readFileSync(path, 'utf-8').trim()
+  if (!raw) return {}
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+function opencodeMcpEntry(cmd: LaunchCmd): Record<string, unknown> {
+  return { type: 'local', command: [cmd.command, ...cmd.args], enabled: true }
+}
+
+function opencodeAttached(): boolean {
+  try {
+    const cfg = readOpencodeConfig(opencodeConfigPath())
+    const mcp = cfg.mcp as Record<string, unknown> | undefined
+    return !!mcp && typeof mcp === 'object' && SERVER_NAME in mcp
+  } catch {
+    return false
+  }
+}
+
+function opencodeAttach(cmd: LaunchCmd): void {
+  const path = opencodeConfigPath()
+  const cfg = readOpencodeConfig(path)
+  if (!cfg.$schema) cfg.$schema = 'https://opencode.ai/config.json'
+  const mcp = (typeof cfg.mcp === 'object' && cfg.mcp !== null ? cfg.mcp : {}) as Record<string, unknown>
+  mcp[SERVER_NAME] = opencodeMcpEntry(cmd)
+  cfg.mcp = mcp
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+}
+
+function opencodeDetach(): void {
+  const path = opencodeConfigPath()
+  if (!existsSync(path)) return
+  const cfg = readOpencodeConfig(path)
+  const mcp = cfg.mcp as Record<string, unknown> | undefined
+  if (mcp && SERVER_NAME in mcp) {
+    delete mcp[SERVER_NAME]
+    writeFileSync(path, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+  }
+}
 
 // The absolute command a host CLI runs to launch our MCP server over stdio.
 export interface LaunchCmd {
@@ -60,6 +124,14 @@ interface HostCli {
   add?: (_cmd: LaunchCmd) => string[]
   remove?: string[]
   list: string[]
+  // File-based attach for a host with no scriptable `mcp add` (OpenCode). When
+  // set, attach/detach/status edit and read the host's config file directly
+  // instead of shelling out to the host CLI, so the host is no longer "manual".
+  file?: {
+    attach: (_cmd: LaunchCmd) => void
+    detach: () => void
+    attached: () => boolean
+  }
 }
 
 const HOSTS: HostCli[] = [
@@ -100,10 +172,11 @@ const HOSTS: HostCli[] = [
     list: ['mcp', 'list'],
   },
   {
-    // opencode's `mcp add` prompts interactively and has no remove subcommand,
-    // so we cannot attach or detach it without a prompt. Report it as manual.
+    // opencode's `mcp add` prompts interactively for a local server's command, so
+    // we attach it by writing its config JSON directly instead.
     provider: 'opencode',
     list: ['mcp', 'list'],
+    file: { attach: opencodeAttach, detach: opencodeDetach, attached: opencodeAttached },
   },
 ]
 
@@ -192,8 +265,8 @@ export function hostStatus(): HostStatus[] {
       bin: hostBin(host),
       label: hostLabel(host),
       installed,
-      attached: installed && isAttached(host),
-      manual: host.add === undefined,
+      attached: installed && (host.file ? host.file.attached() : isAttached(host)),
+      manual: host.add === undefined && host.file === undefined,
     }
   })
 }
@@ -202,16 +275,26 @@ export function hostStatus(): HostStatus[] {
 export function attach(key: string, force = false): AttachResult {
   const host = findHost(key)
   const label = hostLabel(host)
-  if (!host.add) {
+  if (!host.add && !host.file) {
     return {
       key,
       label,
       ok: false,
-      message: `${label} must be added manually: in OpenCode, add a stdio MCP server named "${SERVER_NAME}" that runs reevesagents mcp`,
+      message: `${label} must be added manually: add a stdio MCP server named "${SERVER_NAME}" that runs reevesagents mcp`,
     }
   }
   if (!isInstalled(hostBin(host))) {
     return { key, label, ok: false, message: `${hostBin(host)} is not installed` }
+  }
+  // File-based host (OpenCode): write its config directly. force is a no-op since
+  // writing already overwrites any existing entry.
+  if (host.file) {
+    try {
+      host.file.attach(resolveLaunchCmd())
+      return { key, label, ok: true, message: force ? 'reattached' : 'attached' }
+    } catch (err) {
+      return { key, label, ok: false, message: `could not edit config (add it manually): ${cliError(err)}` }
+    }
   }
   try {
     // force rewrites a stale registration (e.g. a pre-1.5.0 bare-name command that
@@ -220,7 +303,8 @@ export function attach(key: string, force = false): AttachResult {
     if (force && host.remove) {
       try { runHostCommand(host, host.remove) } catch { /* nothing to remove; fine */ }
     }
-    runHostCommand(host, host.add(resolveLaunchCmd()))
+    // Reached only for CLI-based hosts (the file branch returned above), so add is set.
+    runHostCommand(host, host.add!(resolveLaunchCmd()))
     return { key, label, ok: true, message: force ? 'reattached' : 'attached' }
   } catch (err) {
     return { key, label, ok: false, message: cliError(err) }
@@ -231,14 +315,22 @@ export function attach(key: string, force = false): AttachResult {
 export function detach(key: string): AttachResult {
   const host = findHost(key)
   const label = hostLabel(host)
-  if (!host.remove) {
+  if (!host.remove && !host.file) {
     return { key, label, ok: false, message: `${label} must be removed manually` }
   }
   if (!isInstalled(hostBin(host))) {
     return { key, label, ok: false, message: `${hostBin(host)} is not installed` }
   }
+  if (host.file) {
+    try {
+      host.file.detach()
+      return { key, label, ok: true, message: 'detached' }
+    } catch (err) {
+      return { key, label, ok: false, message: cliError(err) }
+    }
+  }
   try {
-    runHostCommand(host, host.remove)
+    runHostCommand(host, host.remove!)
     return { key, label, ok: true, message: 'detached' }
   } catch (err) {
     return { key, label, ok: false, message: cliError(err) }
@@ -251,9 +343,10 @@ export function detach(key: string): AttachResult {
 // "already exists" failure from the CLI's own mcp add.
 export function attachAll(force = false): AttachResult[] {
   return HOSTS
-    .filter(host => host.add && isInstalled(hostBin(host)))
+    .filter(host => (host.add || host.file) && isInstalled(hostBin(host)))
     .map(host => {
-      if (!force && isAttached(host)) {
+      const attached = host.file ? host.file.attached() : isAttached(host)
+      if (!force && attached) {
         return { key: host.provider, label: hostLabel(host), ok: true, message: 'already attached' }
       }
       return attach(host.provider, force)

--- a/test/mcp-extra.test.ts
+++ b/test/mcp-extra.test.ts
@@ -263,21 +263,19 @@ describe('mcp installer extra', () => {
     expect(removeCall[1]).toEqual(['mcp', 'remove', 'reevesagents'])
   })
 
-  it('attachAll returns results only for installed drivable hosts', async () => {
-    // claude + hermes installed and drivable; opencode installed but manual;
-    // codex/kimi/qwen not installed.
+  it('attachAll returns results for installed drivable hosts, including file-based opencode', async () => {
+    // claude + hermes (CLI) and opencode (file-based) installed; codex/kimi/qwen not.
     wireEnv({ installed: new Set(['claude', 'hermes', 'opencode']) })
     const { attachAll } = await loadInstaller()
 
     const results = attachAll()
-    expect(results.map(r => r.key).sort()).toEqual(['cc', 'hermes'])
+    expect(results.map(r => r.key).sort()).toEqual(['cc', 'hermes', 'opencode'])
     expect(results.every(r => r.ok)).toBe(true)
-    // opencode is manual and the rest are uninstalled, so none of them appear.
-    expect(results.find(r => r.key === 'opencode')).toBeUndefined()
+    // uninstalled hosts never appear.
     expect(results.find(r => r.key === 'codex')).toBeUndefined()
   })
 
-  it('hostStatus marks opencode manual and a which-throwing host not installed', async () => {
+  it('hostStatus marks opencode drivable and a which-throwing host not installed', async () => {
     // Only opencode resolves; claude's `which` throws, so it must read as not
     // installed (and therefore not attached).
     wireEnv({
@@ -288,7 +286,7 @@ describe('mcp installer extra', () => {
     const status = hostStatus()
 
     const opencode = status.find(h => h.key === 'opencode')!
-    expect(opencode.manual).toBe(true)
+    expect(opencode.manual).toBe(false)
     expect(opencode.installed).toBe(true)
 
     const cc = status.find(h => h.key === 'cc')!

--- a/test/mcp-installer.test.ts
+++ b/test/mcp-installer.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -95,7 +95,7 @@ describe('mcp installer', () => {
       expect(cc.attached).toBe(false)
     })
 
-    it('marks opencode as manual because it has no add command', async () => {
+    it('marks opencode as drivable via its config file (not manual)', async () => {
       wireEnv({
         installed: new Set(['opencode']),
         listOutput: { opencode: 'reevesagents: reevesagents mcp' },
@@ -103,15 +103,15 @@ describe('mcp installer', () => {
       const { hostStatus } = await loadInstaller()
 
       const opencode = hostStatus().find(h => h.key === 'opencode')!
-      expect(opencode.manual).toBe(true)
+      expect(opencode.manual).toBe(false)
       expect(opencode.installed).toBe(true)
     })
 
-    it('marks every drivable host as manual:false', async () => {
+    it('marks every host as manual:false', async () => {
       wireEnv({ installed: new Set(), listOutput: {} })
       const { hostStatus } = await loadInstaller()
 
-      const drivable = hostStatus().filter(h => h.key !== 'opencode')
+      const drivable = hostStatus()
       expect(drivable.map(h => h.manual)).toEqual(drivable.map(() => false))
     })
 
@@ -228,15 +228,42 @@ describe('mcp installer', () => {
       expect(argv[argv.length - 1]).toBe('mcp')
     })
 
-    it('returns ok:false with a manual message for opencode and runs no command', async () => {
+    it('attaches opencode by writing its config file (no CLI add call)', async () => {
       wireEnv({ installed: new Set(['opencode']), listOutput: {} })
       const { attach } = await loadInstaller()
 
       const result = attach('opencode')
-      expect(result.ok).toBe(false)
-      expect(result.message).toMatch(/manual/i)
-      // Manual hosts short-circuit before any which / list / add call.
-      expect(execFileSync).not.toHaveBeenCalled()
+      expect(result.ok).toBe(true)
+      // File-based: the config now advertises the reevesagents MCP server, and
+      // no `opencode mcp add` command was ever shelled out.
+      const cfgPath = join(process.env.REEVES_HOME!, '.config', 'opencode', 'opencode.json')
+      const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+      expect(cfg.mcp.reevesagents.type).toBe('local')
+      expect(cfg.mcp.reevesagents.command.at(-1)).toBe('mcp')
+      expect(execFileSync).not.toHaveBeenCalledWith('opencode', expect.arrayContaining(['mcp', 'add']), expect.anything())
+    })
+
+    it('opencode attach preserves existing config and detach removes only its entry', async () => {
+      wireEnv({ installed: new Set(['opencode']), listOutput: {} })
+      const dir = join(process.env.REEVES_HOME!, '.config', 'opencode')
+      mkdirSync(dir, { recursive: true })
+      const cfgPath = join(dir, 'opencode.json')
+      writeFileSync(cfgPath, JSON.stringify({ theme: 'dark', mcp: { other: { type: 'local', command: ['x'] } } }), 'utf-8')
+      const { attach, detach, hostStatus } = await loadInstaller()
+
+      attach('opencode')
+      let cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+      expect(cfg.theme).toBe('dark')                       // unrelated key preserved
+      expect(cfg.mcp.other).toBeTruthy()                   // other MCP server preserved
+      expect(cfg.mcp.reevesagents.enabled).toBe(true)
+      expect(hostStatus().find(h => h.key === 'opencode')!.attached).toBe(true)
+
+      detach('opencode')
+      cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+      expect(cfg.mcp.reevesagents).toBeUndefined()         // only our entry removed
+      expect(cfg.mcp.other).toBeTruthy()
+      expect(cfg.theme).toBe('dark')
+      expect(hostStatus().find(h => h.key === 'opencode')!.attached).toBe(false)
     })
 
     it('returns ok:false when the drivable host is not installed', async () => {
@@ -347,8 +374,8 @@ describe('mcp installer', () => {
   })
 
   describe('attachAll', () => {
-    it('only attaches installed drivable hosts and skips manual and uninstalled ones', async () => {
-      // claude + qwen installed and drivable; opencode installed but manual;
+    it('attaches every installed drivable host, including file-based opencode', async () => {
+      // claude + qwen (CLI-based) and opencode (file-based) installed;
       // codex/kimi/hermes not installed.
       wireEnv({
         installed: new Set(['claude', 'qwen', 'opencode']),
@@ -358,18 +385,16 @@ describe('mcp installer', () => {
 
       const results = attachAll()
       const keys = results.map(r => r.key).sort()
-      expect(keys).toEqual(['cc', 'qwen'])
+      expect(keys).toEqual(['cc', 'opencode', 'qwen'])
       expect(results.every(r => r.ok)).toBe(true)
 
-      // opencode is manual, so it must never appear.
-      expect(results.find(r => r.key === 'opencode')).toBeUndefined()
       // No add was issued for an uninstalled host.
       const codexAdd = execFileSync.mock.calls.find(c => c[0] === 'codex' && c[1]?.[1] === 'add')
       expect(codexAdd).toBeUndefined()
     })
 
     it('returns an empty list when no drivable host is installed', async () => {
-      wireEnv({ installed: new Set(['opencode']), listOutput: {} })
+      wireEnv({ installed: new Set(), listOutput: {} })
       const { attachAll } = await loadInstaller()
 
       expect(attachAll()).toEqual([])
@@ -410,14 +435,13 @@ describe('mcp installer', () => {
       expect(removeCall[1]).toEqual(['mcp', 'remove', 'reevesagents'])
     })
 
-    it('returns ok:false with a manual message for opencode', async () => {
+    it('detaches opencode by editing its config file (no CLI remove call)', async () => {
       wireEnv({ installed: new Set(['opencode']), listOutput: {} })
       const { detach } = await loadInstaller()
 
       const result = detach('opencode')
-      expect(result.ok).toBe(false)
-      expect(result.message).toMatch(/manual/i)
-      expect(execFileSync).not.toHaveBeenCalled()
+      expect(result.ok).toBe(true)
+      expect(execFileSync).not.toHaveBeenCalledWith('opencode', expect.arrayContaining(['mcp', 'remove']), expect.anything())
     })
   })
 })

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -64,6 +64,22 @@ describe('onboarding state', () => {
     expect(state.ready).toBe(true)
   })
 
+  it('runOnboarding installs the skill (part of the one-command setup)', async () => {
+    // No host installed, so attachAll is empty and verify is skipped; this
+    // isolates the skill-install step of the combined setup.
+    wireEnv({ installed: new Set() })
+    const { runOnboarding } = await import('../src/core/onboard.js')
+    const result = await runOnboarding()
+
+    expect(result.attached).toEqual([])
+    expect(result.verify).toBeNull()
+    expect(result.skills.length).toBe(2)
+    expect(result.skills.every(skill => skill.ok)).toBe(true)
+
+    const { skillsStatus } = await import('../src/core/skills.js')
+    expect(skillsStatus().every(skill => skill.present && skill.current)).toBe(true)
+  })
+
   it('is not ready without a provider CLI', async () => {
     wireEnv({ installed: new Set() })
     const { buildOnboardingState } = await import('../src/core/onboard.js')

--- a/test/web/server-actions.test.ts
+++ b/test/web/server-actions.test.ts
@@ -429,7 +429,7 @@ describe('agent control (mcp hosts)', () => {
     const cc = body.hosts.find(h => h.key === 'cc')!
     expect(cc).toMatchObject({ key: 'cc', bin: 'claude', installed: true, attached: false, manual: false })
     const opencode = body.hosts.find(h => h.key === 'opencode')!
-    expect(opencode.manual).toBe(true)
+    expect(opencode.manual).toBe(false)
   })
 
   it('attaches and detaches a drivable host', async () => {
@@ -456,8 +456,6 @@ describe('agent control (mcp hosts)', () => {
     const body = JSON.parse(res.body) as { results: Array<{ key: string; ok: boolean }>; hosts: unknown[] }
     expect(body.results.length).toBeGreaterThan(0)
     expect(body.results.every(r => r.ok)).toBe(true)
-    // opencode is manual, so attach-all never drives it.
-    expect(body.results.find(r => r.key === 'opencode')).toBeUndefined()
   })
 
   it('rejects an unknown host key', async () => {


### PR DESCRIPTION
Closes #15.

Makes getting reevesagents working across CLIs a single command, and fixes the misleading host status.

## Changes
- **OpenCode auto-attach**: `reevesagents attach` now wires OpenCode by writing `~/.config/opencode/opencode.json` directly (it has no scriptable `mcp add` for a local server). The write merges into existing config and detach removes only the reevesagents entry, so OpenCode drops the "manual" flag.
- **One-command setup**: `setup --attach` installs the skill in the same run, so one command sets up the MCP and the skill on every skill-aware CLI.
- **Accurate status**: bumped the status probe timeout 5s -> 20s. `claude mcp list` health-checks every configured MCP server, so with a few remote ones it exceeded 5s and an attached reevesagents read as "detached".
- **Docs**: note that Codex sandboxes MCP tool calls by default; run it with `--sandbox danger-full-access` (or a profile) to let it drive agents.

## Testing
- `pnpm verify:release` green (typecheck, lint, 733 tests, build, smoke, package, install matrix).
- Verified end to end: Claude Code, Codex, OpenCode, and Kimi Code each discover and call the reevesagents MCP (`list_providers` returns the live provider catalog). New unit tests cover the OpenCode config round-trip and skill-in-setup.