### PR TITLE
fix(runtime): verify tmux ids belong to their run session before targeting them

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,6 +192,15 @@ function openTuiSession(command: string): void {
 
 function openTarget(id: string): void {
   const target = resolveOpenTarget(id)
+  // Stored window ids are only valid inside their recorded session: after a tmux
+  // server restart the same "@N" can name an unrelated window, so verify
+  // membership before targeting anything.
+  if (!tmuxSessionExists(target.session)) {
+    throw new Error(`tmux session not found: ${target.session}`)
+  }
+  if (target.windowId.startsWith('@') && !tmuxWindowIds(target.session).includes(target.windowId)) {
+    throw new Error('agent window no longer exists (tmux server may have restarted)')
+  }
   const tmuxTarget = `${target.session}:${target.windowId}`
   if (process.env.TMUX) {
     execFileSync('tmux', ['switch-client', '-t', tmuxTarget], { stdio: 'ignore' })

--- a/src/core/reaper.ts
+++ b/src/core/reaper.ts
@@ -30,7 +30,7 @@ export interface ReapedAgent {
 
 export interface SweepOptions {
   driver?: RuntimeDriver
-  targetExists?: (_windowId: string) => boolean
+  targetExists?: (_windowId: string, _session: string) => boolean
   tmuxAvailable?: () => boolean
   now?: () => number
   maxLifetimeMs?: number
@@ -55,7 +55,7 @@ export function sweepAgents(options: SweepOptions = {}): { reaped: ReapedAgent[]
     if (agent.ended_at || agent.headless) continue
     const ageMs = now() - new Date(agent.started_at).getTime()
     let reason: ReapReason | null = null
-    if (agent.tmux_window_id && !targetExists(agent.tmux_window_id)) {
+    if (agent.tmux_window_id && !targetExists(agent.tmux_window_id, agent.tmux_session)) {
       reason = 'window-gone'
     } else if (maxLifetimeMs > 0 && ageMs > maxLifetimeMs) {
       reason = 'lifetime-exceeded'

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -497,7 +497,8 @@ export function readAgentInbox(runId: string, agentId: string): Message[] {
 export function defaultTmuxSessionExists(session: string): boolean {
   if (!session) return false
   try {
-    const result = spawnSync('tmux', ['has-session', '-t', session], { stdio: 'ignore' })
+    // "=" forces an exact session-name match; a bare name would prefix-match.
+    const result = spawnSync('tmux', ['has-session', '-t', `=${session}`], { stdio: 'ignore' })
     return result.status === 0
   } catch {
     return false
@@ -513,12 +514,20 @@ export function defaultTmuxAvailable(): boolean {
   }
 }
 
-export function defaultTmuxTargetExists(target: string): boolean {
-  if (!target) return false
+export function defaultTmuxTargetExists(target: string, session: string): boolean {
+  if (!target || !session) return false
   try {
-    const format = target.startsWith('%') ? '#{pane_id}' : '#{window_id}'
-    const result = spawnSync('tmux', ['display-message', '-p', '-t', target, format], { encoding: 'utf8' })
-    return result.status === 0 && result.stdout.trim() === target
+    // Window/pane ids are only unique per tmux-server lifetime; after a server
+    // restart they are reassigned, so a bare "-t @N" probe can match an unrelated
+    // window. Identity is the (session name, id) pair: run session names embed the
+    // run id, so they never collide across server generations. Membership in the
+    // exact-matched session is the only sound check; "=SESS:@N" targets are NOT
+    // (tmux silently falls back to another window when @N is absent from SESS).
+    const args = target.startsWith('%')
+      ? ['list-panes', '-s', '-t', `=${session}`, '-F', '#{pane_id}']
+      : ['list-windows', '-t', `=${session}`, '-F', '#{window_id}']
+    const result = spawnSync('tmux', args, { encoding: 'utf8' })
+    return result.status === 0 && result.stdout.split('\n').some(line => line.trim() === target)
   } catch {
     return false
   }
@@ -526,7 +535,7 @@ export function defaultTmuxTargetExists(target: string): boolean {
 
 export interface AutoCleanupOptions {
   sessionExists?: (_session: string) => boolean
-  targetExists?: (_target: string) => boolean
+  targetExists?: (_target: string, _session: string) => boolean
   tmuxAvailable?: () => boolean
   cleanStale?: boolean
 }
@@ -536,7 +545,7 @@ export function runHasLiveTmuxTarget(run: RunRecord, options: AutoCleanupOptions
   const sessionExists = options.sessionExists ?? defaultTmuxSessionExists
   const agents = listAgents(run.id).filter(agent => !agent.ended_at)
   const windowedAgents = agents.filter(agent => !agent.headless && agent.tmux_window_id)
-  if (windowedAgents.length > 0) return windowedAgents.some(agent => targetExists(agent.tmux_window_id))
+  if (windowedAgents.length > 0) return windowedAgents.some(agent => targetExists(agent.tmux_window_id, agent.tmux_session))
   return sessionExists(run.tmux_session)
 }
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1,6 +1,10 @@
 // Tmux agent-run runtime: one run owns one tmux session with independent CLI agents.
 // Inputs: run/agent configs. Outputs: run and agent JSON records plus tmux side effects.
-// Invariant: stored tmux targets use stable window/pane ids, never mutable indexes.
+// Invariant: stored tmux targets use window/pane ids, never mutable indexes, and an id
+// is only trusted as the pair (session name, id). Ids are unique per tmux-server
+// lifetime only: after a server restart they are reassigned, so a bare "@N"/"%N" can
+// name an unrelated window. Every consumer verifies membership in the exact-matched
+// session before targeting (windowInSession/paneInSession below).
 
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
@@ -147,6 +151,35 @@ function pasteTextToPane(driver: RuntimeDriver, paneId: string, text: string): v
   }
 }
 
+const STALE_WINDOW_ERROR = 'agent window no longer exists (tmux server may have restarted)'
+
+// Membership probes for the (session name, id) identity pair. Qualified targets like
+// "=SESS:@N" are no substitute: when @N is absent from SESS, tmux silently resolves
+// to another window in SESS instead of failing (verified on tmux 3.4). Listing the
+// exact-matched session and checking membership is the only sound test. After a
+// positive check, bare-id targeting is unambiguous because tmux never reuses ids
+// within one server lifetime; the remaining race is a server restart between check
+// and use, which tmux offers no way to close.
+function windowInSession(driver: RuntimeDriver, session: string, windowId: string): boolean {
+  if (!session || !windowId) return false
+  try {
+    return driver.tmux(['list-windows', '-t', `=${session}`, '-F', '#{window_id}'])
+      .split('\n').some(line => line.trim() === windowId)
+  } catch {
+    return false
+  }
+}
+
+function paneInSession(driver: RuntimeDriver, session: string, paneId: string): boolean {
+  if (!session || !paneId) return false
+  try {
+    return driver.tmux(['list-panes', '-s', '-t', `=${session}`, '-F', '#{pane_id}'])
+      .split('\n').some(line => line.trim() === paneId)
+  } catch {
+    return false
+  }
+}
+
 function sanitizeName(raw: string): string {
   const cleaned = raw.trim().replace(/[^a-zA-Z0-9_-]/g, '-').replace(/-+/g, '-').slice(0, 40)
   return cleaned || 'run'
@@ -264,6 +297,7 @@ function sendDelayedStartupInput(
 
   function waitForReadyThenSend(previousOutput = '', waitedMs = 0): void {
     try {
+      if (!paneInSession(driver, agent.tmux_session, agent.tmux_pane_id)) return
       const output = driver.tmux(['capture-pane', '-p', '-e', '-S', '-80', '-t', agent.tmux_pane_id])
       if (paneLooksReady(output, previousOutput) || waitedMs >= STARTUP_READY_TIMEOUT_MS) {
         sendStartupTask()
@@ -540,8 +574,11 @@ export function spawnWorker(request: SpawnWorkerRequest, options: RuntimeOptions
 export function openReeves(runId: string, options: RuntimeOptions = {}): void {
   const driver = options.driver ?? realDriver
   const run = readRun(runId)
-  if (!run.reeves_window_id) throw new Error('Reeves TUI window is unavailable for this run')
-  const target = `${run.reeves_session ?? run.tmux_session}:${run.reeves_window_id}`
+  const reevesSession = run.reeves_session ?? run.tmux_session
+  if (!run.reeves_window_id || !windowInSession(driver, reevesSession, run.reeves_window_id)) {
+    throw new Error('Reeves TUI window is unavailable for this run')
+  }
+  const target = `${reevesSession}:${run.reeves_window_id}`
   try { driver.tmux(['switch-client', '-t', target]) } catch { /* no attached client */ }
   driver.tmux(['select-window', '-t', target])
 }
@@ -558,6 +595,7 @@ export function openAgent(agentId: string, options: RuntimeOptions = {}): void {
   const driver = options.driver ?? realDriver
   const agent = findAgent(agentId)
   if (agent.headless || !agent.tmux_window_id) throw new Error('This agent is headless - no tmux window exists')
+  if (!windowInSession(driver, agent.tmux_session, agent.tmux_window_id)) throw new Error(STALE_WINDOW_ERROR)
   const target = `${agent.tmux_session}:${agent.tmux_window_id}`
   try { driver.tmux(['switch-client', '-t', target]) } catch { /* no attached client */ }
   driver.tmux(['select-window', '-t', target])
@@ -571,6 +609,7 @@ export function peekAgent(agentId: string, lines = 10, options: RuntimeOptions =
   try {
     const agent = findAgent(agentId)
     if (agent.headless || !agent.tmux_pane_id) return '(headless agent - no output)'
+    if (!paneInSession(driver, agent.tmux_session, agent.tmux_pane_id)) return ''
     let output = driver.tmux(['capture-pane', '-p', '-e', '-S', String(-n), '-t', agent.tmux_pane_id])
     if (!output.trim()) {
       try { output = driver.tmux(['capture-pane', '-p', '-e', '-a', '-S', String(-n), '-t', agent.tmux_pane_id]) } catch { /* no alternate screen */ }
@@ -585,6 +624,7 @@ export function sendText(agentId: string, text: string, options: RuntimeOptions 
   const driver = options.driver ?? realDriver
   const agent = findAgent(agentId)
   if (agent.headless || !agent.tmux_pane_id) throw new Error('This agent is headless - no tmux pane exists')
+  if (!paneInSession(driver, agent.tmux_session, agent.tmux_pane_id)) throw new Error(STALE_WINDOW_ERROR)
   pasteTextToPane(driver, agent.tmux_pane_id, text)
   lastPasteAtByPane.set(agent.tmux_pane_id, Date.now())
   if (!agent.ended_at && agent.task_status === 'queued') updateAgent(agent.run_id, agent.id, { task_status: 'working' })
@@ -608,6 +648,7 @@ export function sendKey(agentId: string, key: AllowedKey, options: RuntimeOption
   const agent = findAgent(agentId)
   if (agent.headless || !agent.tmux_pane_id) throw new Error('This agent is headless - no tmux pane exists')
   if (!ALLOWED_KEYS.includes(key)) throw new Error(`Unsupported key: ${String(key)}`)
+  if (!paneInSession(driver, agent.tmux_session, agent.tmux_pane_id)) throw new Error(STALE_WINDOW_ERROR)
   if (key === 'enter') {
     const lastPasteAt = lastPasteAtByPane.get(agent.tmux_pane_id) ?? 0
     const remaining = POST_PASTE_ENTER_DELAY_MS - (Date.now() - lastPasteAt)
@@ -628,20 +669,29 @@ export function killAgent(agentId: string, options: RuntimeOptions = {}): AgentR
   const driver = options.driver ?? realDriver
   const agent = findAgent(agentId)
   const run = readRun(agent.run_id)
-  try {
-    driver.tmux(['kill-window', '-t', agent.tmux_window_id])
-  } catch {
-    // already gone
+  // Only kill the window when the stored id still belongs to this run's session; a
+  // stale id (server restart) would name an unrelated window. A failed check means
+  // the window is already gone, so the record teardown below proceeds either way.
+  if (windowInSession(driver, agent.tmux_session, agent.tmux_window_id)) {
+    try {
+      driver.tmux(['kill-window', '-t', agent.tmux_window_id])
+    } catch {
+      // already gone
+    }
   }
   const endedAt = nowIso()
   updateAgent(agent.run_id, agent.id, { ended_at: endedAt, task_status: 'done' })
   const updatedAgent = readAgent(agent.run_id, agent.id)
   const endedRun = endRunIfNoLiveAgents(agent.run_id, endedAt)
   if (endedRun.status === 'ended' || endedRun.ended_at !== null) {
-    try {
-      driver.tmux(['kill-session', '-t', run.tmux_session])
-    } catch {
-      // session may already be gone
+    // Same guard as stopRun: never kill a session the run shares with the reeves TUI.
+    const runOwnsSession = !!run.reeves_session && run.reeves_session !== run.tmux_session
+    if (runOwnsSession) {
+      try {
+        driver.tmux(['kill-session', '-t', `=${run.tmux_session}`])
+      } catch {
+        // session may already be gone
+      }
     }
     archiveAndRemoveRun(run.id, 'ended')
   }
@@ -656,14 +706,14 @@ export function stopRun(runId: string, options: RuntimeOptions = {}): RunRecord 
   const runOwnsSession = !!run.reeves_session && run.reeves_session !== run.tmux_session
   if (runOwnsSession) {
     try {
-      driver.tmux(['kill-session', '-t', run.tmux_session])
+      driver.tmux(['kill-session', '-t', `=${run.tmux_session}`])
     } catch {
       // session may already be gone
     }
   }
   for (const agent of listAgents(run.id)) {
     if (agent.ended_at) continue
-    if (!runOwnsSession && agent.tmux_window_id) {
+    if (!runOwnsSession && windowInSession(driver, agent.tmux_session, agent.tmux_window_id)) {
       try {
         driver.tmux(['kill-window', '-t', agent.tmux_window_id])
       } catch {
@@ -702,6 +752,7 @@ export function openTmuxTarget(id: string, options: RuntimeOptions = {}): { sess
     } catch {
       throw new Error(`no run or agent found: ${id}`)
     }
+    if (!windowInSession(driver, session, window)) throw new Error(STALE_WINDOW_ERROR)
   }
   const target = `${session}:${window}`
   try { driver.tmux(['switch-client', '-t', target]) } catch { /* no attached client to switch */ }

--- a/src/web/bridge.ts
+++ b/src/web/bridge.ts
@@ -12,7 +12,7 @@ import type { Server } from 'node:http'
 import type { Duplex } from 'node:stream'
 import { WebSocketServer, type WebSocket, type RawData } from 'ws'
 import pty from '@lydell/node-pty'
-import { findAgent, readRun } from '../core/runs.js'
+import { defaultTmuxTargetExists, findAgent, readRun } from '../core/runs.js'
 import { isAllowedHostHeader, isAllowedOrigin } from './guards.js'
 
 type Pty = ReturnType<typeof pty.spawn>
@@ -103,12 +103,21 @@ function openBridge(ws: WebSocket, id: string, bridges: Set<Bridge>): void {
     return
   }
 
+  // A stale window id (tmux server restarted, ids reassigned) would stream an
+  // unrelated window's terminal into the browser and accept keystrokes into it.
+  // Only bridge ids verified to still live inside the recorded session.
+  if (!defaultTmuxTargetExists(target.windowId, target.session)) {
+    send(ws, { t: 'e', m: 'agent window no longer exists (tmux server may have restarted)' })
+    ws.close()
+    return
+  }
+
   // Ephemeral viewer session grouped with the run session: it shares the run's
   // windows but keeps an independent current window, so each card views its own
   // terminal without disturbing the human's attached client.
   const viewer = `reevesweb_${randomBytes(4).toString('hex')}`
   try {
-    execFileSync('tmux', ['new-session', '-d', '-s', viewer, '-t', target.session], { stdio: 'ignore' })
+    execFileSync('tmux', ['new-session', '-d', '-s', viewer, '-t', `=${target.session}`], { stdio: 'ignore' })
     execFileSync('tmux', ['select-window', '-t', `${viewer}:${target.windowId}`], { stdio: 'ignore' })
   } catch {
     try { execFileSync('tmux', ['kill-session', '-t', viewer], { stdio: 'ignore' }) } catch { /* nothing to clean */ }

--- a/test/cli-parity.test.ts
+++ b/test/cli-parity.test.ts
@@ -114,13 +114,20 @@ function makeAgent(id: string, runId: string, overrides: Partial<AgentRecord> = 
 // returns empty output, which is all the spawn/send/key paths need.
 function wireTmux(): void {
   let next = 1
+  // Membership probes list these; seeded records use @1/%1, the anchor is @0/%0.
+  const windows = new Set(['@0', '@1'])
+  const panes = new Set(['%0', '%1'])
   execFileSync.mockImplementation((file: string, args: string[]) => {
     if (file !== 'tmux') return Buffer.from('')
     if (args[0] === 'display-message') return '@0 %0'
     if (args[0] === 'new-window') {
       const id = next++
+      windows.add(`@${id}`)
+      panes.add(`%${id}`)
       return `@${id} %${id}`
     }
+    if (args[0] === 'list-windows') return [...windows].join('\n')
+    if (args[0] === 'list-panes') return [...panes].join('\n')
     if (args[0] === 'capture-pane') return 'ready'
     return ''
   })
@@ -130,6 +137,8 @@ function wireTmux(): void {
 // spawn preflight sees them as not installed.
 function wireTmuxWithMissing(missingBins: string[]): void {
   let next = 1
+  const windows = new Set(['@0', '@1'])
+  const panes = new Set(['%0', '%1'])
   execFileSync.mockImplementation((file: string, args: string[]) => {
     if (file === 'which') {
       if (missingBins.includes(args[0] as string)) throw new Error(`which: no ${args[0]}`)
@@ -139,8 +148,12 @@ function wireTmuxWithMissing(missingBins: string[]): void {
     if (args[0] === 'display-message') return '@0 %0'
     if (args[0] === 'new-window') {
       const id = next++
+      windows.add(`@${id}`)
+      panes.add(`%${id}`)
       return `@${id} %${id}`
     }
+    if (args[0] === 'list-windows') return [...windows].join('\n')
+    if (args[0] === 'list-panes') return [...panes].join('\n')
     if (args[0] === 'capture-pane') return 'ready'
     return ''
   })

--- a/test/mcp-head.test.ts
+++ b/test/mcp-head.test.ts
@@ -26,6 +26,9 @@ class FakeDriver implements RuntimeDriver {
   calls: Array<{ args: string[], input?: string }> = []
   delays: number[] = []
   nextWindow = 1
+  // Windows/panes the fake server currently holds; membership probes list these.
+  windows = new Set<string>(['@0'])
+  panes = new Set<string>(['%0'])
   captureOutput = '\u001b[31mready\u001b[0m sk-ant-api03-abcdefghij1234567890abcdef'
 
   tmux(args: string[], input?: string): string {
@@ -33,8 +36,12 @@ class FakeDriver implements RuntimeDriver {
     if (args[0] === 'display-message') return '@0 %0'
     if (args[0] === 'new-window') {
       const id = this.nextWindow++
+      this.windows.add(`@${id}`)
+      this.panes.add(`%${id}`)
       return `@${id} %${id}`
     }
+    if (args[0] === 'list-windows') return [...this.windows].join('\n')
+    if (args[0] === 'list-panes') return [...this.panes].join('\n')
     if (args[0] === 'capture-pane') return this.captureOutput
     return ''
   }
@@ -164,7 +171,7 @@ describe('startRunWithHead', () => {
     expect(listRuns().map(run => run.id)).not.toContain(result.run.id)
     expect(listRunHistory().map(record => record.id)).toContain(result.run.id)
     expect(driver.calls).toEqual(expect.arrayContaining([
-      { args: ['kill-session', '-t', result.run.tmux_session] },
+      { args: ['kill-session', '-t', `=${result.run.tmux_session}`] },
     ]))
   })
 })

--- a/test/mcp-parity.test.ts
+++ b/test/mcp-parity.test.ts
@@ -26,14 +26,21 @@ beforeEach(() => {
   execFileSync.mockReset()
   // The real tmux driver does execFileSync(...).trim(), so every return is a
   // string. `which` output is unused (the call only needs to not throw).
+  // Membership probes list these; tests seed records with ids up to @7.
+  const windows = new Set(['@0', '@1', '@7'])
+  const panes = new Set(['%0', '%1', '%7'])
   execFileSync.mockImplementation((file: string, args: string[]) => {
     if (file === 'which') return `/usr/bin/${args[0]}\n`
     if (file !== 'tmux') return ''
     if (args[0] === 'new-window') {
       windowSeq += 1
+      windows.add(`@${windowSeq}`)
+      panes.add(`%${windowSeq}`)
       return `@${windowSeq} %${windowSeq}\n`
     }
     if (args[0] === 'display-message') return '@0 %0\n'
+    if (args[0] === 'list-windows') return `${[...windows].join('\n')}\n`
+    if (args[0] === 'list-panes') return `${[...panes].join('\n')}\n`
     if (args[0] === 'capture-pane') return 'ready\n'
     return ''
   })

--- a/test/reaper.test.ts
+++ b/test/reaper.test.ts
@@ -95,6 +95,30 @@ describe('zombie-agent reaper', () => {
     expect(agents.find(a => a.id === 'dead')!.ended_at).not.toBeNull()
   })
 
+  it('reaps a stale id as window-gone even when the same id is live in another session', () => {
+    writeRun(makeRun('r1'))
+    writeAgent(makeAgent('r1', 'stale', { tmux_window_id: '@3' }))
+
+    // After a tmux server restart "@3" can belong to an unrelated session. The
+    // probe must judge the (id, session) pair, never the id alone, or the zombie
+    // reads as alive and a later kill hits the stranger's window.
+    const probed: Array<[string, string]> = []
+    const { reaped } = sweepAgents({
+      driver: noopDriver,
+      targetExists: (id, session) => {
+        probed.push([id, session])
+        return id === '@3' && session === 'reeves-other'
+      },
+      maxLifetimeMs: 0,
+    })
+
+    expect(probed).toContainEqual(['@3', 'reeves-r1'])
+    expect(reaped).toHaveLength(1)
+    expect(reaped[0]).toMatchObject({ agent_id: 'stale', reason: 'window-gone' })
+    // Reaping the run's only agent tears the run down and archives it.
+    expect(listAgents('r1')).toHaveLength(0)
+  })
+
   it('reaps an agent older than max_lifetime_ms and spares a younger one', () => {
     const now = 10 * HOUR
     writeRun(makeRun('r1'))

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -33,6 +33,10 @@ class FakeDriver implements RuntimeDriver {
   calls: Array<{ args: string[], input?: string }> = []
   delays: number[] = []
   nextWindow = 1
+  // Windows/panes the fake server currently holds; membership probes list these.
+  // Tests simulate a tmux server restart by deleting an agent's ids from the sets.
+  windows = new Set<string>(['@0'])
+  panes = new Set<string>(['%0'])
   captureOutput = '\u001b[31mready\u001b[0m sk-ant-api03-abcdefghij1234567890abcdef'
 
   tmux(args: string[], input?: string): string {
@@ -40,7 +44,17 @@ class FakeDriver implements RuntimeDriver {
     if (args[0] === 'display-message') return '@0 %0'
     if (args[0] === 'new-window') {
       const id = this.nextWindow++
+      this.windows.add(`@${id}`)
+      this.panes.add(`%${id}`)
       return `@${id} %${id}`
+    }
+    if (args[0] === 'list-windows') return [...this.windows].join('\n')
+    if (args[0] === 'list-panes') return [...this.panes].join('\n')
+    if (args[0] === 'kill-window') {
+      const target = args[args.indexOf('-t') + 1] ?? ''
+      this.windows.delete(target)
+      this.panes.delete(`%${target.slice(1)}`)
+      return ''
     }
     if (args[0] === 'capture-pane') return this.captureOutput
     return ''
@@ -185,7 +199,7 @@ describe('agent-run runtime', () => {
       { args: ['send-keys', '-t', terminal.tmux_pane_id, 'Enter'] },
       { args: ['send-keys', '-t', terminal.tmux_pane_id, 'C-c'] },
       { args: ['kill-window', '-t', terminal.tmux_window_id] },
-      { args: ['kill-session', '-t', result.run.tmux_session] },
+      { args: ['kill-session', '-t', `=${result.run.tmux_session}`] },
     ]))
   })
 
@@ -206,8 +220,64 @@ describe('agent-run runtime', () => {
     expect(listRunHistory()).toHaveLength(1)
     expect(listRunHistory()[0]).toMatchObject({ id: result.run.id, status: 'ended' })
     expect(driver.calls).toEqual(expect.arrayContaining([
-      { args: ['kill-session', '-t', result.run.tmux_session] },
+      { args: ['kill-session', '-t', `=${result.run.tmux_session}`] },
     ]))
+  })
+
+  it('skips kill-window when the stored id no longer lives in the run session', async () => {
+    const driver = new FakeDriver()
+    const { startRun, killAgent } = await import('../src/core/runtime.js')
+    const { listRunHistory, readRun } = await import('../src/core/runs.js')
+
+    const result = startRun({
+      name: 'stale',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const agent = result.agents[0]!
+
+    // Simulate a tmux server restart: the recorded ids are no longer members of
+    // the run session. On a real restart the same "@N" can name an unrelated
+    // window, so killAgent must not emit kill-window for it.
+    driver.windows.delete(agent.tmux_window_id)
+    driver.panes.delete(agent.tmux_pane_id)
+    const before = driver.calls.length
+
+    expect(killAgent(agent.id, { driver }).ended_at).not.toBeNull()
+
+    const after = driver.calls.slice(before)
+    expect(after.some(call => call.args[0] === 'kill-window')).toBe(false)
+    expect(after).toEqual(expect.arrayContaining([
+      { args: ['kill-session', '-t', `=${result.run.tmux_session}`] },
+    ]))
+    expect(() => readRun(result.run.id)).toThrow(/Run not found/)
+    expect(listRunHistory().map(record => record.id)).toContain(result.run.id)
+  })
+
+  it('refuses reads and input to a stale pane instead of touching a reused id', async () => {
+    const driver = new FakeDriver()
+    const { startRun, peekAgent, sendText, sendKey, openAgent } = await import('../src/core/runtime.js')
+
+    const result = startRun({
+      name: 'stale-io',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const agent = result.agents[0]!
+
+    driver.windows.delete(agent.tmux_window_id)
+    driver.panes.delete(agent.tmux_pane_id)
+    const before = driver.calls.length
+
+    expect(peekAgent(agent.id, 5, { driver })).toBe('')
+    expect(() => sendText(agent.id, 'hello', { driver })).toThrow(/tmux server may have restarted/)
+    expect(() => sendKey(agent.id, 'enter', { driver })).toThrow(/tmux server may have restarted/)
+    expect(() => openAgent(agent.id, { driver })).toThrow(/tmux server may have restarted/)
+
+    const after = driver.calls.slice(before)
+    const touched = after.filter(call =>
+      ['capture-pane', 'load-buffer', 'paste-buffer', 'send-keys', 'select-window'].includes(call.args[0]!))
+    expect(touched).toEqual([])
   })
 
   it('creates the reeves anchor window with an append target, not a bare name', async () => {

--- a/test/web/server-actions.test.ts
+++ b/test/web/server-actions.test.ts
@@ -122,6 +122,8 @@ function installFakeRuntimeBins(): void {
     '    done',
     '    exit 0 ;;',
     '  capture-pane) echo "ready"; exit 0 ;;',
+    '  list-windows) echo "@0"; echo "@1"; echo "@2"; echo "@3"; echo "@4"; exit 0 ;;',
+    '  list-panes) echo "%0"; echo "%1"; echo "%2"; echo "%3"; echo "%4"; exit 0 ;;',
     '  *) exit 0 ;;',
     'esac',
     '',


### PR DESCRIPTION
## Summary

- tmux window/pane ids are only unique per tmux-server lifetime; after a server restart they are reassigned, so a stale record's `@N` can name an unrelated window. `kill-window -t @N` destroyed a stranger's window in production, and the reaper's `display-message` probe reported the zombie as alive because the reused id resolved server-wide.
- An id is now only trusted as the pair (session name, id): run session names embed the run id and never collide across server generations. Every consumer (kill, stop, reap, peek, send_text/send_key, startup input, open paths, CLI open, web terminal bridge) verifies membership via `list-windows`/`list-panes -s` on the `=`-exact-matched session before targeting, and treats non-membership as window-gone.
- Qualified targets like `=SESS:@N` are no substitute: tmux silently resolves them to another window when `@N` is absent from SESS (verified on tmux 3.4). Session-name targets now use `=` exact match, and `killAgent` gains the same shared-session guard `stopRun` already had.
- 3 new regression tests pin the incident (pair-identity reap, stale-id kill skip, stale-pane input refusal). Verified live end to end: with a record rewritten to a dead session, reap flags window-gone and the same-numbered live window elsewhere survives untouched.

Closes #17

## Scope

- [x] Stable CLI/TUI
- [x] Web UI beta
- [ ] Docs or release packaging

## Checks

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm smoke:cli`
- [x] `pnpm check:package`
- [x] `pnpm check:install-matrix`

## Notes

- Target branch: master
- Risk: low; no schema changes, old records on disk read correctly as window-gone. Each peek/send/open adds one tmux membership probe (~1-2 ms).
