### PR TITLE
fix(mcp): recognize Kimi Code as a host instead of reporting it detached

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,9 @@ remove. ReevesAgents only calls each CLI's own command and never edits provider
 config files by hand. OpenCode is the exception: it has no scriptable `mcp add`
 for a local server, so ReevesAgents attaches it by writing the `reevesagents`
 entry into its `~/.config/opencode/opencode.json` directly (and removes just that
-entry on detach).
+entry on detach). Kimi Code is handled the same way: when the `kimi` on PATH is
+Kimi Code rather than the legacy Kimi CLI, ReevesAgents reads its plugin and
+`~/.kimi-code/mcp.json` for status and attaches through that config file.
 
 Codex sandboxes MCP tool calls by default, which blocks reevesagents from
 launching agents in tmux. Run Codex with full access when driving agents, for

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -111,6 +111,11 @@ hermes. For each one you can attach, detach, or attach all.
 - OpenCode is the exception: it has no scriptable `mcp add` for a local server, so
   reeves attaches it by writing the `reevesagents` entry into
   `~/.config/opencode/opencode.json` directly, and detach removes only that entry.
+- Kimi Code (the successor to the legacy Kimi CLI) also has no `kimi mcp add`; when
+  the `kimi` on PATH is Kimi Code, reeves reads its plugin/`~/.kimi-code/mcp.json`
+  state for status and attaches via that config file (skipping the write when the
+  reevesagents plugin already provides the server). The legacy Kimi CLI still uses
+  its `kimi mcp add`.
 - Codex sandboxes MCP tool calls by default, which blocks reevesagents from
   spawning agents in tmux; run Codex with `--sandbox danger-full-access` (or a
   profile that sets it) when driving agents.

--- a/src/mcp/installer.ts
+++ b/src/mcp/installer.ts
@@ -83,6 +83,90 @@ function opencodeDetach(): void {
   }
 }
 
+// File-based attach ops for a host with no scriptable `mcp add`.
+export interface HostFileOps {
+  attach: (_cmd: LaunchCmd) => void
+  detach: () => void
+  attached: () => boolean
+}
+
+// Kimi Code (the successor to the legacy Kimi CLI) has no `kimi mcp add` subcommand;
+// it reads MCP servers from ~/.kimi-code/mcp.json and from installed plugins. The
+// `kimi` binary can be either tool, so we detect Kimi Code at runtime and, for it,
+// attach via the config file (like OpenCode) instead of the legacy CLI commands.
+function kimiCodeHome(): string {
+  // REEVES_HOME is the sandbox override tests/sandboxes set; it wins so a test
+  // never reads the real ~/.kimi-code. Otherwise honor Kimi Code's own
+  // KIMI_CODE_HOME, then default to ~/.kimi-code.
+  if (process.env.REEVES_HOME) return join(process.env.REEVES_HOME, '.kimi-code')
+  return process.env.KIMI_CODE_HOME || join(homedir(), '.kimi-code')
+}
+
+// True when the `kimi` on PATH is Kimi Code, not the legacy Kimi CLI. Legacy prints
+// "kimi, version X"; Kimi Code prints a bare semver. Returns false (legacy path)
+// when the binary is missing or its version cannot be read.
+function isKimiCode(bin: string): boolean {
+  try {
+    const out = execFileSync(bin, ['--version'], {
+      encoding: 'utf8',
+      timeout: STATUS_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+    return out !== '' && !/^kimi,/i.test(out)
+  } catch {
+    return false
+  }
+}
+
+function kimiCodePluginAttached(): boolean {
+  try {
+    const installed = JSON.parse(readFileSync(join(kimiCodeHome(), 'plugins', 'installed.json'), 'utf-8')) as { plugins?: Array<{ id?: string; enabled?: boolean }> }
+    return Array.isArray(installed.plugins) && installed.plugins.some(p => p.id === SERVER_NAME && p.enabled !== false)
+  } catch {
+    return false
+  }
+}
+
+function kimiCodeMcpConfig(): Record<string, unknown> {
+  try {
+    const raw = readFileSync(join(kimiCodeHome(), 'mcp.json'), 'utf-8').trim()
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function kimiCodeMcpAttached(): boolean {
+  const servers = kimiCodeMcpConfig().mcpServers as Record<string, unknown> | undefined
+  return !!servers && typeof servers === 'object' && SERVER_NAME in servers
+}
+
+const KIMI_CODE_FILE_OPS: HostFileOps = {
+  attached: () => kimiCodePluginAttached() || kimiCodeMcpAttached(),
+  attach: cmd => {
+    // The reevesagents plugin already provides the server; do not also add it to
+    // mcp.json or Kimi Code would load two servers named reevesagents.
+    if (kimiCodePluginAttached()) return
+    const path = join(kimiCodeHome(), 'mcp.json')
+    const cfg = kimiCodeMcpConfig()
+    const servers = (typeof cfg.mcpServers === 'object' && cfg.mcpServers !== null ? cfg.mcpServers : {}) as Record<string, unknown>
+    servers[SERVER_NAME] = { command: cmd.command, args: cmd.args }
+    cfg.mcpServers = servers
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+  },
+  detach: () => {
+    const path = join(kimiCodeHome(), 'mcp.json')
+    if (!existsSync(path)) return
+    const cfg = kimiCodeMcpConfig()
+    const servers = cfg.mcpServers as Record<string, unknown> | undefined
+    if (servers && SERVER_NAME in servers) {
+      delete servers[SERVER_NAME]
+      writeFileSync(path, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+    }
+  },
+}
+
 // The absolute command a host CLI runs to launch our MCP server over stdio.
 export interface LaunchCmd {
   command: string
@@ -127,11 +211,7 @@ interface HostCli {
   // File-based attach for a host with no scriptable `mcp add` (OpenCode). When
   // set, attach/detach/status edit and read the host's config file directly
   // instead of shelling out to the host CLI, so the host is no longer "manual".
-  file?: {
-    attach: (_cmd: LaunchCmd) => void
-    detach: () => void
-    attached: () => boolean
-  }
+  file?: HostFileOps
 }
 
 const HOSTS: HostCli[] = [
@@ -186,6 +266,15 @@ function hostBin(host: HostCli): string {
 
 function hostLabel(host: HostCli): string {
   return PROVIDER_REGISTRY[host.provider].displayName
+}
+
+// The file-based attach ops for a host, if any: OpenCode's static ops, or Kimi
+// Code's when the `kimi` binary turns out to be Kimi Code (detected at runtime).
+// When this returns ops, attach/detach/status use them instead of the CLI path.
+function hostFileOps(host: HostCli): HostFileOps | undefined {
+  if (host.file) return host.file
+  if (host.provider === 'kimi' && isKimiCode(hostBin(host))) return KIMI_CODE_FILE_OPS
+  return undefined
 }
 
 export interface HostStatus {
@@ -260,12 +349,13 @@ function findHost(key: string): HostCli {
 export function hostStatus(): HostStatus[] {
   return HOSTS.map(host => {
     const installed = isInstalled(hostBin(host))
+    const file = installed ? hostFileOps(host) : undefined
     return {
       key: host.provider,
       bin: hostBin(host),
       label: hostLabel(host),
       installed,
-      attached: installed && (host.file ? host.file.attached() : isAttached(host)),
+      attached: installed && (file ? file.attached() : isAttached(host)),
       manual: host.add === undefined && host.file === undefined,
     }
   })
@@ -286,11 +376,12 @@ export function attach(key: string, force = false): AttachResult {
   if (!isInstalled(hostBin(host))) {
     return { key, label, ok: false, message: `${hostBin(host)} is not installed` }
   }
-  // File-based host (OpenCode): write its config directly. force is a no-op since
-  // writing already overwrites any existing entry.
-  if (host.file) {
+  // File-based host (OpenCode, or Kimi Code detected at runtime): write its config
+  // directly. force is a no-op since writing already overwrites any existing entry.
+  const file = hostFileOps(host)
+  if (file) {
     try {
-      host.file.attach(resolveLaunchCmd())
+      file.attach(resolveLaunchCmd())
       return { key, label, ok: true, message: force ? 'reattached' : 'attached' }
     } catch (err) {
       return { key, label, ok: false, message: `could not edit config (add it manually): ${cliError(err)}` }
@@ -321,9 +412,10 @@ export function detach(key: string): AttachResult {
   if (!isInstalled(hostBin(host))) {
     return { key, label, ok: false, message: `${hostBin(host)} is not installed` }
   }
-  if (host.file) {
+  const file = hostFileOps(host)
+  if (file) {
     try {
-      host.file.detach()
+      file.detach()
       return { key, label, ok: true, message: 'detached' }
     } catch (err) {
       return { key, label, ok: false, message: cliError(err) }
@@ -345,7 +437,8 @@ export function attachAll(force = false): AttachResult[] {
   return HOSTS
     .filter(host => (host.add || host.file) && isInstalled(hostBin(host)))
     .map(host => {
-      const attached = host.file ? host.file.attached() : isAttached(host)
+      const file = hostFileOps(host)
+      const attached = file ? file.attached() : isAttached(host)
       if (!force && attached) {
         return { key: host.provider, label: hostLabel(host), ok: true, message: 'already attached' }
       }

--- a/test/mcp-installer.test.ts
+++ b/test/mcp-installer.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -23,6 +23,9 @@ interface FakeEnv {
   listOutput: Record<string, string>
   // Bins whose add/remove should throw, with the error to throw.
   failAdd?: Record<string, unknown>
+  // When true, `kimi --version` reports Kimi Code (a bare semver) rather than the
+  // legacy Kimi CLI ("kimi, version X").
+  kimiCode?: boolean
 }
 
 function wireEnv(env: FakeEnv): void {
@@ -32,6 +35,11 @@ function wireEnv(env: FakeEnv): void {
       // Honor the { encoding: 'utf8' } callers use (resolveLaunchCmd trims this).
       if (env.installed.has(bin)) return `/usr/bin/${bin}\n`
       throw new Error(`which: ${bin} not found`)
+    }
+    // Version probe: only `kimi` is version-checked, to tell Kimi Code from legacy.
+    if (args[0] === '--version') {
+      if (file === 'kimi') return env.kimiCode ? '0.29.1\n' : 'kimi, version 1.49.0\n'
+      return ''
     }
     // From here `file` is a host bin and `args` is one of its mcp subcommands.
     const sub = args[1]
@@ -442,6 +450,69 @@ describe('mcp installer', () => {
       const result = detach('opencode')
       expect(result.ok).toBe(true)
       expect(execFileSync).not.toHaveBeenCalledWith('opencode', expect.arrayContaining(['mcp', 'remove']), expect.anything())
+    })
+  })
+
+  describe('kimi code host', () => {
+    const kimiHome = () => join(process.env.REEVES_HOME!, '.kimi-code')
+    // REEVES_HOME is shared across the suite, so reset the kimi-code home per test
+    // to keep plugin/mcp.json state from leaking between these cases.
+    beforeEach(() => rmSync(kimiHome(), { recursive: true, force: true }))
+    const writePlugin = (enabled: boolean) => {
+      mkdirSync(join(kimiHome(), 'plugins'), { recursive: true })
+      writeFileSync(join(kimiHome(), 'plugins', 'installed.json'), JSON.stringify({ plugins: [{ id: 'reevesagents', enabled }] }))
+    }
+
+    it('reports kimi attached via its plugin (not "detached") and never probes kimi mcp list', async () => {
+      writePlugin(true)
+      wireEnv({ installed: new Set(['kimi']), listOutput: {}, kimiCode: true })
+      const { hostStatus } = await loadInstaller()
+
+      const kimi = hostStatus().find(h => h.key === 'kimi')!
+      expect(kimi.installed).toBe(true)
+      expect(kimi.attached).toBe(true)
+      expect(execFileSync).not.toHaveBeenCalledWith('kimi', ['mcp', 'list'], expect.anything())
+    })
+
+    it('attaches kimi code by writing ~/.kimi-code/mcp.json (no CLI add)', async () => {
+      wireEnv({ installed: new Set(['kimi']), listOutput: {}, kimiCode: true })
+      const { attach } = await loadInstaller()
+
+      expect(attach('kimi').ok).toBe(true)
+      const cfg = JSON.parse(readFileSync(join(kimiHome(), 'mcp.json'), 'utf-8'))
+      expect(cfg.mcpServers.reevesagents.args.at(-1)).toBe('mcp')
+      expect(execFileSync).not.toHaveBeenCalledWith('kimi', expect.arrayContaining(['mcp', 'add']), expect.anything())
+    })
+
+    it('does not duplicate reevesagents in mcp.json when the plugin already provides it', async () => {
+      writePlugin(true)
+      wireEnv({ installed: new Set(['kimi']), listOutput: {}, kimiCode: true })
+      const { attach } = await loadInstaller()
+
+      expect(attach('kimi').ok).toBe(true)
+      expect(existsSync(join(kimiHome(), 'mcp.json'))).toBe(false)
+    })
+
+    it('detaches kimi code by removing only its mcp.json entry', async () => {
+      mkdirSync(kimiHome(), { recursive: true })
+      writeFileSync(join(kimiHome(), 'mcp.json'), JSON.stringify({ mcpServers: { other: { command: 'x' }, reevesagents: { command: 'n', args: ['mcp'] } } }))
+      wireEnv({ installed: new Set(['kimi']), listOutput: {}, kimiCode: true })
+      const { detach, hostStatus } = await loadInstaller()
+
+      expect(detach('kimi').ok).toBe(true)
+      const cfg = JSON.parse(readFileSync(join(kimiHome(), 'mcp.json'), 'utf-8'))
+      expect(cfg.mcpServers.reevesagents).toBeUndefined()
+      expect(cfg.mcpServers.other).toBeTruthy()
+      expect(hostStatus().find(h => h.key === 'kimi')!.attached).toBe(false)
+      expect(execFileSync).not.toHaveBeenCalledWith('kimi', expect.arrayContaining(['mcp', 'remove']), expect.anything())
+    })
+
+    it('still uses the legacy CLI path for the legacy Kimi CLI', async () => {
+      wireEnv({ installed: new Set(['kimi']), listOutput: {}, kimiCode: false })
+      const { attach } = await loadInstaller()
+
+      expect(attach('kimi').ok).toBe(true)
+      expect(execFileSync).toHaveBeenCalledWith('kimi', expect.arrayContaining(['mcp', 'add']), expect.anything())
     })
   })
 })


### PR DESCRIPTION
Closes #19.

`reevesagents hosts` reported `kimi` as detached even when reevesagents worked in Kimi Code, and `attach kimi` failed, because reevesagents assumed the `kimi` binary was the legacy Kimi CLI (`kimi mcp add` / `kimi mcp list`). Kimi Code has no `kimi mcp` subcommand — it gets MCP servers from installed plugins and `~/.kimi-code/mcp.json`.

## Change
- Detect Kimi Code at runtime: its `--version` is a bare semver, whereas the legacy CLI prints `kimi, version X`.
- For Kimi Code, reuse the file-based attach path (added for OpenCode): status reads its plugin state and `~/.kimi-code/mcp.json`; attach writes that config file, and **skips the write when the reevesagents plugin already provides the server** so Kimi Code never loads two servers named `reevesagents`; detach removes only our entry.
- The legacy Kimi CLI keeps its `kimi mcp add` path unchanged.

## Testing
- `pnpm verify:release` green (typecheck, lint, 741 tests, build, smoke, package, install matrix). New unit tests cover kimi-code detection, plugin-aware status, write/skip-on-plugin attach, and detach. Verified tests never touch the real `~/.kimi-code`.
- End to end on a machine where `kimi` is Kimi Code: `reevesagents hosts` now shows kimi attached (via its plugin) instead of detached.