### PR TITLE
refactor(core): consolidate tmux access into a single core/tmux.ts adapter

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { execFileSync } from 'node:child_process'
 import { realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { prepareTuiColorEnv } from './utils/color-env.js'
+import { exactSession, sessionExists, windowByName, windowIds } from './core/tmux.js'
 import { runDoctor } from './core/doctor.js'
 import { peekAgent, startRun, startRunFromPreset, spawnWorker, stopRun, killAgent, sendText, sendKey, interrupt, type AllowedKey, ALLOWED_KEYS } from './core/runtime.js'
 import { normalizeProvider, PROVIDERS, detectAvailable, coerceExtraArgs } from './core/providers.js'
@@ -97,61 +98,12 @@ function tmuxAttachCommand(session: string, windowId: string): string {
   return `tmux select-window -t ${quoteShell(`${session}:${windowId}`)} && tmux attach -t ${quoteShell(session)}`
 }
 
-// tmux resolves a bare target against both session and window names, with prefix matching, so a
-// leftover "reeves-*" session or the equally-named TUI window hijacks it: the wrong session, or an
-// index-1 collision that fails "create window failed: index 1 in use". "=" forces an exact session
-// match; a trailing ":" makes new-window append at the next free index instead of a pinned one.
-function exactSession(session: string): string {
-  return `=${session}`
-}
-
-function tmuxSessionExists(session: string): boolean {
-  try {
-    execFileSync('tmux', ['has-session', '-t', exactSession(session)], { stdio: 'ignore' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-function tmuxWindowIds(session: string): string[] {
-  try {
-    return execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}'], { encoding: 'utf8' })
-      .split('\n')
-      .map(line => line.trim())
-      .filter(Boolean)
-  } catch {
-    return []
-  }
-}
-
-interface TmuxWindowInfo {
-  id: string
-  command: string
-}
-
-function tmuxWindowByName(session: string, name: string): TmuxWindowInfo | null {
-  try {
-    const rows = execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}\t#{window_name}\t#{pane_current_command}'], { encoding: 'utf8' })
-      .split('\n')
-      .map(line => line.trim())
-      .filter(Boolean)
-    for (const row of rows) {
-      const [windowId, windowName, command = ''] = row.split('\t')
-      if (windowId && windowName === name) return { id: windowId, command }
-    }
-  } catch {
-    // Session may not exist yet.
-  }
-  return null
-}
-
 function isTuiCommand(command: string): boolean {
   return command === 'node' || command === 'reevesagents'
 }
 
 function clearTuiSessionExcept(session: string, keepWindowId: string): void {
-  for (const windowId of tmuxWindowIds(session)) {
+  for (const windowId of windowIds(session)) {
     if (windowId === keepWindowId) continue
     try {
       execFileSync('tmux', ['kill-window', '-t', windowId], { stdio: 'ignore' })
@@ -161,6 +113,8 @@ function clearTuiSessionExcept(session: string, keepWindowId: string): void {
   }
 }
 
+// The trailing ":" makes new-window append at the next free index instead of a
+// pinned one, avoiding "create window failed: index 1 in use".
 export function tuiNewWindowArgs(session: string, window: string, command: string): string[] {
   return ['new-window', '-d', '-P', '-F', '#{window_id}', '-t', `${exactSession(session)}:`, '-n', window, command]
 }
@@ -173,12 +127,12 @@ function openTuiSession(command: string): void {
   const session = 'reeves'
   const window = 'reeves'
 
-  if (!tmuxSessionExists(session)) {
+  if (!sessionExists(session)) {
     execFileSync('tmux', ['new-session', '-s', session, '-n', window, command], { stdio: 'inherit' })
     return
   }
 
-  const existing = tmuxWindowByName(session, window)
+  const existing = windowByName(session, window)
   if (existing && !isTuiCommand(existing.command)) {
     try { execFileSync('tmux', ['kill-window', '-t', existing.id], { stdio: 'ignore' }) } catch { /* already gone */ }
   }
@@ -195,10 +149,10 @@ function openTarget(id: string): void {
   // Stored window ids are only valid inside their recorded session: after a tmux
   // server restart the same "@N" can name an unrelated window, so verify
   // membership before targeting anything.
-  if (!tmuxSessionExists(target.session)) {
+  if (!sessionExists(target.session)) {
     throw new Error(`tmux session not found: ${target.session}`)
   }
-  if (target.windowId.startsWith('@') && !tmuxWindowIds(target.session).includes(target.windowId)) {
+  if (target.windowId.startsWith('@') && !windowIds(target.session).includes(target.windowId)) {
     throw new Error('agent window no longer exists (tmux server may have restarted)')
   }
   const tmuxTarget = `${target.session}:${target.windowId}`

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,13 +1,13 @@
 // Setup and environment health checks for ReevesAgents v1.
 // Doctor does not clean runtime state or kill agents.
 
-import { execFileSync } from 'node:child_process'
 import { accessSync, constants, existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
 import type { CheckResult, Provider } from './types.js'
 import { detectAvailable, inspectProviderCompatibility } from './providers.js'
 import { listRuns, runsDir, stateRoot } from './runs.js'
+import { tmuxVersion } from './tmux.js'
 import { WEB_EXTRA_MODULES } from '../web/extras.js'
 import { providerDisplayName } from '../utils/display.js'
 import { resolveLaunchCmd } from '../mcp/installer.js'
@@ -89,17 +89,14 @@ export function platformSupportCheck(
 }
 
 export function checkTmux(): CheckResult {
-  try {
-    const versionStr = execFileSync('tmux', ['-V'], { encoding: 'utf8' }).trim()
-    const match = versionStr.match(/tmux (\d+)\.(\d+)/)
-    if (!match) return { name: 'tmux', status: 'warn', detail: `unexpected version format: ${versionStr}` }
-    const major = parseInt(match[1] ?? '0', 10)
-    const minor = parseInt(match[2] ?? '0', 10)
-    if (major < 3) return { name: 'tmux', status: 'warn', detail: `tmux ${major}.${minor}; upgrade to 3.0+ recommended` }
-    return { name: 'tmux', status: 'ok', detail: `tmux ${major}.${minor}` }
-  } catch {
-    return { name: 'tmux', status: 'fail', detail: 'not on PATH' }
-  }
+  const versionStr = tmuxVersion()
+  if (!versionStr) return { name: 'tmux', status: 'fail', detail: 'not on PATH' }
+  const match = versionStr.match(/tmux (\d+)\.(\d+)/)
+  if (!match) return { name: 'tmux', status: 'warn', detail: `unexpected version format: ${versionStr}` }
+  const major = parseInt(match[1] ?? '0', 10)
+  const minor = parseInt(match[2] ?? '0', 10)
+  if (major < 3) return { name: 'tmux', status: 'warn', detail: `tmux ${major}.${minor}; upgrade to 3.0+ recommended` }
+  return { name: 'tmux', status: 'ok', detail: `tmux ${major}.${minor}` }
 }
 
 function checkProviders(): CheckResult {

--- a/src/core/reaper.ts
+++ b/src/core/reaper.ts
@@ -10,13 +10,9 @@
 // autoCleanupRuns knows nothing about.
 
 import { loadConfig } from './config.js'
-import {
-  defaultTmuxAvailable,
-  defaultTmuxTargetExists,
-  listAgents,
-  nowMs,
-} from './runs.js'
-import { killAgent, type RuntimeDriver } from './runtime.js'
+import { listAgents, nowMs } from './runs.js'
+import { targetExists as tmuxTargetExists, tmuxAvailable, type RuntimeDriver } from './tmux.js'
+import { killAgent } from './runtime.js'
 
 export type ReapReason = 'window-gone' | 'lifetime-exceeded'
 
@@ -43,10 +39,10 @@ export function sweepAgents(options: SweepOptions = {}): { reaped: ReapedAgent[]
   // An injected targetExists (tests) implies tmux is present; otherwise probe once.
   // Without tmux we cannot tell a dead window from a live one, so reap nothing
   // rather than nuke every record, mirroring autoCleanupRuns' missing-tmux guard.
-  const haveTmux = options.targetExists ? true : (options.tmuxAvailable ?? defaultTmuxAvailable)()
+  const haveTmux = options.targetExists ? true : (options.tmuxAvailable ?? tmuxAvailable)()
   if (!haveTmux) return { reaped: [] }
 
-  const targetExists = options.targetExists ?? defaultTmuxTargetExists
+  const targetExists = options.targetExists ?? tmuxTargetExists
   const now = options.now ?? nowMs
   const maxLifetimeMs = options.maxLifetimeMs ?? loadConfig().global.max_lifetime_ms
 

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -19,7 +19,6 @@ import {
 import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { spawnSync } from 'node:child_process'
 import type {
   AgentRecord,
   Message,
@@ -32,6 +31,7 @@ import type {
 } from './types.js'
 import { redactSecrets } from '../utils/display.js'
 import { isProvider } from './providers.js'
+import * as tmux from './tmux.js'
 
 export function stateRoot(): string {
   return process.env.REEVES_REGISTRY || join(homedir(), '.reeves')
@@ -494,45 +494,6 @@ export function readAgentInbox(runId: string, agentId: string): Message[] {
   })
 }
 
-export function defaultTmuxSessionExists(session: string): boolean {
-  if (!session) return false
-  try {
-    // "=" forces an exact session-name match; a bare name would prefix-match.
-    const result = spawnSync('tmux', ['has-session', '-t', `=${session}`], { stdio: 'ignore' })
-    return result.status === 0
-  } catch {
-    return false
-  }
-}
-
-export function defaultTmuxAvailable(): boolean {
-  try {
-    const result = spawnSync('tmux', ['-V'], { stdio: 'ignore' })
-    return result.status === 0
-  } catch {
-    return false
-  }
-}
-
-export function defaultTmuxTargetExists(target: string, session: string): boolean {
-  if (!target || !session) return false
-  try {
-    // Window/pane ids are only unique per tmux-server lifetime; after a server
-    // restart they are reassigned, so a bare "-t @N" probe can match an unrelated
-    // window. Identity is the (session name, id) pair: run session names embed the
-    // run id, so they never collide across server generations. Membership in the
-    // exact-matched session is the only sound check; "=SESS:@N" targets are NOT
-    // (tmux silently falls back to another window when @N is absent from SESS).
-    const args = target.startsWith('%')
-      ? ['list-panes', '-s', '-t', `=${session}`, '-F', '#{pane_id}']
-      : ['list-windows', '-t', `=${session}`, '-F', '#{window_id}']
-    const result = spawnSync('tmux', args, { encoding: 'utf8' })
-    return result.status === 0 && result.stdout.split('\n').some(line => line.trim() === target)
-  } catch {
-    return false
-  }
-}
-
 export interface AutoCleanupOptions {
   sessionExists?: (_session: string) => boolean
   targetExists?: (_target: string, _session: string) => boolean
@@ -541,8 +502,8 @@ export interface AutoCleanupOptions {
 }
 
 export function runHasLiveTmuxTarget(run: RunRecord, options: AutoCleanupOptions = {}): boolean {
-  const targetExists = options.targetExists ?? defaultTmuxTargetExists
-  const sessionExists = options.sessionExists ?? defaultTmuxSessionExists
+  const targetExists = options.targetExists ?? tmux.targetExists
+  const sessionExists = options.sessionExists ?? tmux.sessionExists
   const agents = listAgents(run.id).filter(agent => !agent.ended_at)
   const windowedAgents = agents.filter(agent => !agent.headless && agent.tmux_window_id)
   if (windowedAgents.length > 0) return windowedAgents.some(agent => targetExists(agent.tmux_window_id, agent.tmux_session))
@@ -555,12 +516,12 @@ export function runHasLiveTmuxTarget(run: RunRecord, options: AutoCleanupOptions
 // cleaned (the stale check is skipped) so a missing-tmux environment never
 // nukes the user's run records. Per-run failures are swallowed.
 export function autoCleanupRuns(options: AutoCleanupOptions = {}): { removed: string[]; archived: string[] } {
-  const sessionExists = options.sessionExists ?? defaultTmuxSessionExists
-  const targetExists = options.targetExists ?? defaultTmuxTargetExists
+  const sessionExists = options.sessionExists ?? tmux.sessionExists
+  const targetExists = options.targetExists ?? tmux.targetExists
   // If the caller injected tmux checks (test drivers), treat tmux as available and skip the real probe.
   const tmuxAvailable = options.sessionExists || options.targetExists
     ? () => true
-    : options.tmuxAvailable ?? defaultTmuxAvailable
+    : options.tmuxAvailable ?? tmux.tmuxAvailable
   const haveTmux = options.cleanStale === false ? false : tmuxAvailable()
   const removed: string[] = []
   const archived: string[] = []

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1,12 +1,9 @@
 // Tmux agent-run runtime: one run owns one tmux session with independent CLI agents.
 // Inputs: run/agent configs. Outputs: run and agent JSON records plus tmux side effects.
 // Invariant: stored tmux targets use window/pane ids, never mutable indexes, and an id
-// is only trusted as the pair (session name, id). Ids are unique per tmux-server
-// lifetime only: after a server restart they are reassigned, so a bare "@N"/"%N" can
-// name an unrelated window. Every consumer verifies membership in the exact-matched
-// session before targeting (windowInSession/paneInSession below).
+// is only trusted as the pair (session name, id); see core/tmux.ts for the identity
+// doctrine and the membership probes every consumer must use.
 
-import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import stripAnsi from 'strip-ansi'
 import type {
@@ -38,7 +35,10 @@ import { loadConfig } from './config.js'
 import { loadPreset } from './store.js'
 import { buildCommand, detectAvailable, isProvider } from './providers.js'
 import { resolveWorkingDir, shellQuote } from './provider-launch.js'
+import { paneInSession, realDriver, STALE_WINDOW_ERROR, windowInSession, type RuntimeDriver } from './tmux.js'
 import { providerDisplayName, redactSecrets } from '../utils/display.js'
+
+export type { RuntimeDriver } from './tmux.js'
 
 export interface AgentLaunchConfig {
   nickname?: string
@@ -69,11 +69,6 @@ export interface SpawnWorkerRequest extends AgentLaunchConfig {
   ready_delay_ms?: number
 }
 
-export interface RuntimeDriver {
-  tmux(_args: string[], _input?: string): string
-  delay(_fn: () => void, _ms: number): void
-}
-
 export interface RuntimeOptions {
   driver?: RuntimeDriver
   available?: Record<Provider, boolean>
@@ -98,19 +93,6 @@ export const ALLOWED_KEYS = [
 ] as const
 
 export type AllowedKey = typeof ALLOWED_KEYS[number]
-
-const realDriver: RuntimeDriver = {
-  tmux(args, input) {
-    return execFileSync('tmux', args, {
-      encoding: 'utf8',
-      input,
-      stdio: input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
-    }).trim()
-  },
-  delay(fn, ms) {
-    setTimeout(fn, ms)
-  },
-}
 
 const POST_PASTE_ENTER_DELAY_MS = 1000
 const STARTUP_READY_POLL_MS = 1000
@@ -148,35 +130,6 @@ function pasteTextToPane(driver: RuntimeDriver, paneId: string, text: string): v
     driver.tmux(['paste-buffer', '-b', bufferName, '-t', paneId])
   } finally {
     try { driver.tmux(['delete-buffer', '-b', bufferName]) } catch { /* buffer already gone */ }
-  }
-}
-
-const STALE_WINDOW_ERROR = 'agent window no longer exists (tmux server may have restarted)'
-
-// Membership probes for the (session name, id) identity pair. Qualified targets like
-// "=SESS:@N" are no substitute: when @N is absent from SESS, tmux silently resolves
-// to another window in SESS instead of failing (verified on tmux 3.4). Listing the
-// exact-matched session and checking membership is the only sound test. After a
-// positive check, bare-id targeting is unambiguous because tmux never reuses ids
-// within one server lifetime; the remaining race is a server restart between check
-// and use, which tmux offers no way to close.
-function windowInSession(driver: RuntimeDriver, session: string, windowId: string): boolean {
-  if (!session || !windowId) return false
-  try {
-    return driver.tmux(['list-windows', '-t', `=${session}`, '-F', '#{window_id}'])
-      .split('\n').some(line => line.trim() === windowId)
-  } catch {
-    return false
-  }
-}
-
-function paneInSession(driver: RuntimeDriver, session: string, paneId: string): boolean {
-  if (!session || !paneId) return false
-  try {
-    return driver.tmux(['list-panes', '-s', '-t', `=${session}`, '-F', '#{pane_id}'])
-      .split('\n').some(line => line.trim() === paneId)
-  } catch {
-    return false
   }
 }
 

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -1,0 +1,141 @@
+// Single home for tmux process access and the target-identity rules.
+//
+// Identity doctrine: tmux window/pane ids ("@N"/"%N") are unique only per
+// tmux-server lifetime. After a server restart they are reassigned from 0, so a
+// stored id alone can name an unrelated window. An id is only trusted as the
+// pair (session name, id): run session names embed the run id, so they never
+// collide across server generations. Membership in the exact-matched session is
+// the only sound check; qualified targets like "=SESS:@N" are NOT (when @N is
+// absent from SESS, tmux silently resolves to another window in SESS instead of
+// failing; verified on tmux 3.4). After a positive membership check, bare-id
+// targeting is unambiguous because tmux never reuses ids within one server
+// lifetime; the remaining race is a server restart between check and use, which
+// tmux offers no way to close.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+
+// Injectable seam for everything that shells out to tmux with pacing. Tests
+// substitute a fake; production uses realDriver.
+export interface RuntimeDriver {
+  tmux(_args: string[], _input?: string): string
+  delay(_fn: () => void, _ms: number): void
+}
+
+export const realDriver: RuntimeDriver = {
+  tmux(args, input) {
+    return execFileSync('tmux', args, {
+      encoding: 'utf8',
+      input,
+      stdio: input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+    }).trim()
+  },
+  delay(fn, ms) {
+    setTimeout(fn, ms)
+  },
+}
+
+export const STALE_WINDOW_ERROR = 'agent window no longer exists (tmux server may have restarted)'
+
+// tmux resolves a bare target against both session and window names, with prefix
+// matching, so a leftover "reeves-*" session or an equally-named window hijacks
+// it. "=" forces an exact session match.
+export function exactSession(session: string): string {
+  return `=${session}`
+}
+
+export function tmuxAvailable(): boolean {
+  try {
+    const result = spawnSync('tmux', ['-V'], { stdio: 'ignore' })
+    return result.status === 0
+  } catch {
+    return false
+  }
+}
+
+// Raw `tmux -V` output (e.g. "tmux 3.4"), or null when tmux is missing.
+export function tmuxVersion(): string | null {
+  try {
+    return execFileSync('tmux', ['-V'], { encoding: 'utf8' }).trim()
+  } catch {
+    return null
+  }
+}
+
+export function sessionExists(session: string): boolean {
+  if (!session) return false
+  try {
+    const result = spawnSync('tmux', ['has-session', '-t', exactSession(session)], { stdio: 'ignore' })
+    return result.status === 0
+  } catch {
+    return false
+  }
+}
+
+// Membership probe for the (session name, id) identity pair; see the doctrine
+// comment above for why listing the session is the only sound check.
+export function targetExists(target: string, session: string): boolean {
+  if (!target || !session) return false
+  try {
+    const args = target.startsWith('%')
+      ? ['list-panes', '-s', '-t', exactSession(session), '-F', '#{pane_id}']
+      : ['list-windows', '-t', exactSession(session), '-F', '#{window_id}']
+    const result = spawnSync('tmux', args, { encoding: 'utf8' })
+    return result.status === 0 && result.stdout.split('\n').some(line => line.trim() === target)
+  } catch {
+    return false
+  }
+}
+
+export function windowIds(session: string): string[] {
+  try {
+    return execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}'], { encoding: 'utf8' })
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+export interface TmuxWindowInfo {
+  id: string
+  command: string
+}
+
+export function windowByName(session: string, name: string): TmuxWindowInfo | null {
+  try {
+    const rows = execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}\t#{window_name}\t#{pane_current_command}'], { encoding: 'utf8' })
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+    for (const row of rows) {
+      const [windowId, windowName, command = ''] = row.split('\t')
+      if (windowId && windowName === name) return { id: windowId, command }
+    }
+  } catch {
+    // Session may not exist yet.
+  }
+  return null
+}
+
+// Driver-based membership probes for runtime paths that must honor an injected
+// fake driver. Same identity rule as targetExists, different transport.
+export function windowInSession(driver: RuntimeDriver, session: string, windowId: string): boolean {
+  if (!session || !windowId) return false
+  try {
+    return driver.tmux(['list-windows', '-t', exactSession(session), '-F', '#{window_id}'])
+      .split('\n').some(line => line.trim() === windowId)
+  } catch {
+    return false
+  }
+}
+
+export function paneInSession(driver: RuntimeDriver, session: string, paneId: string): boolean {
+  if (!session || !paneId) return false
+  try {
+    return driver.tmux(['list-panes', '-s', '-t', exactSession(session), '-F', '#{pane_id}'])
+      .split('\n').some(line => line.trim() === paneId)
+  } catch {
+    return false
+  }
+}

--- a/src/web/bridge.ts
+++ b/src/web/bridge.ts
@@ -5,14 +5,15 @@
 // client. Each connection gets an ephemeral grouped viewer session that is
 // disposed on disconnect; the provider's own window is never killed here.
 
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
 import { URL } from 'node:url'
 import type { Server } from 'node:http'
 import type { Duplex } from 'node:stream'
 import { WebSocketServer, type WebSocket, type RawData } from 'ws'
 import pty from '@lydell/node-pty'
-import { defaultTmuxTargetExists, findAgent, readRun } from '../core/runs.js'
+import { targetExists, tmuxAvailable } from '../core/tmux.js'
+import { findAgent, readRun } from '../core/runs.js'
 import { isAllowedHostHeader, isAllowedOrigin } from './guards.js'
 
 type Pty = ReturnType<typeof pty.spawn>
@@ -65,14 +66,6 @@ export function parseClientFrame(raw: RawData | string): ClientFrame | null {
   return null
 }
 
-function tmuxAvailable(): boolean {
-  try {
-    return spawnSync('tmux', ['-V'], { stdio: 'ignore' }).status === 0
-  } catch {
-    return false
-  }
-}
-
 function send(ws: WebSocket, frame: Record<string, unknown>): void {
   if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(frame))
 }
@@ -106,7 +99,7 @@ function openBridge(ws: WebSocket, id: string, bridges: Set<Bridge>): void {
   // A stale window id (tmux server restarted, ids reassigned) would stream an
   // unrelated window's terminal into the browser and accept keystrokes into it.
   // Only bridge ids verified to still live inside the recorded session.
-  if (!defaultTmuxTargetExists(target.windowId, target.session)) {
+  if (!targetExists(target.windowId, target.session)) {
     send(ws, { t: 'e', m: 'agent window no longer exists (tmux server may have restarted)' })
     ws.close()
     return


### PR DESCRIPTION
## Summary

- tmux was shelled out from five places (runtime driver, runs probes, cli TUI-launcher helpers, doctor version check, web bridge), each re-deriving the `=`-exact-match rule and the (session name, id) identity doctrine. The #17 fix had to touch all five files; this is the structural cost that removes.
- `src/core/tmux.ts` now owns the `RuntimeDriver` seam, `realDriver`, the identity-doctrine comment (stated once), and every generic probe: `tmuxAvailable`, `tmuxVersion`, `sessionExists`, `targetExists`, `windowIds`, `windowByName`, `windowInSession`, `paneInSession`, `exactSession`, `STALE_WINDOW_ERROR`.
- `runtime.ts` re-exports the `RuntimeDriver` type so all existing importers (reaper, tests) are unchanged. TUI-session policy helpers (`openTuiSession` etc.) stay in `cli.ts`.
- No behavior change: identical tmux argv everywhere, same injectable seams, test counts identical (92 files / 741 tests, win 6/51). Stage A of the agreed restructuring program.

## Scope

- [x] Stable CLI/TUI
- [x] Web UI beta
- [ ] Docs or release packaging

## Checks

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm smoke:cli`
- [x] `pnpm check:package`
- [ ] `pnpm check:install-matrix`

## Notes

- Target branch: master
- Risk: low; pure code motion with named re-exports, no argv or schema changes.