### PR TITLE
refactor(core): split TUI types and secret redaction out of core

### DIFF
--- a/packages/reevesagents-win/src/shared/types.ts
+++ b/packages/reevesagents-win/src/shared/types.ts
@@ -1,4 +1,5 @@
-// Core type definitions for agent-run state, presets, and TUI routing.
+// Core type definitions for agent-run state, presets, and config.
+// TUI routing types (ScreenName, RouterContextValue) live in tui/types.ts.
 
 export type Provider = 'cc' | 'codex' | 'opencode' | 'hermes' | 'kimi' | 'deepseek' | 'pi' | 'qwen' | 'aider'
 
@@ -19,38 +20,6 @@ export type RunStatus = 'running' | 'ended'
 export type RunViewStatus = RunStatus | 'stale'
 
 export type RunHistoryStatus = 'ended' | 'stale'
-
-export type ScreenName =
-  | 'Welcome'
-  | 'LanguageSelect'
-  | 'Runs'
-  | 'RunHistory'
-  | 'Run'
-  | 'RunAgents'
-  | 'RunOutput'
-  | 'RunStop'
-  | 'AgentDetail'
-  | 'AgentOutput'
-  | 'AgentTask'
-  | 'AgentKill'
-  | 'NewRun'
-  | 'NewRunBasics'
-  | 'NewRunRoot'
-  | 'NewRunWorkers'
-  | 'NewRunWorker'
-  | 'NewRunReview'
-  | 'NewRunStarting'
-  | 'AddWorker'
-  | 'Settings'
-  | 'AgentControl'
-  | 'Setup'
-  | 'Reference'
-  | 'Credits'
-  | 'Doctor'
-  | 'DoctorCheck'
-  | 'Approvals'
-  | 'Config'
-  | 'Presets'
 
 export interface Message {
   id: string
@@ -142,26 +111,6 @@ export interface CheckResult {
   name: string
   status: 'ok' | 'warn' | 'fail'
   detail: string
-}
-
-// Router context — browser-like screen history via push/pop/forward/replace.
-export interface RouterContextValue {
-  screen: ScreenName
-  push: (_screen: ScreenName) => void
-  pop: () => void
-  forward: () => void
-  replace: (_screen: ScreenName) => void
-  resetStack: (_screen: ScreenName, _base?: ScreenName[]) => void
-  selectedRunId: string | null
-  setSelectedRunId: (_runId: string | null) => void
-  selectedAgentId: string | null
-  setSelectedAgentId: (_agentId: string | null) => void
-  selectedCheckName: string | null
-  setSelectedCheckName: (_name: string | null) => void
-  selectedWorkerIdx: number | null
-  setSelectedWorkerIdx: (_idx: number | null) => void
-  canBack: boolean
-  canForward: boolean
 }
 
 // Global preferences; no auth, no keys.

--- a/packages/reevesagents-win/test/catalog-drift.test.ts
+++ b/packages/reevesagents-win/test/catalog-drift.test.ts
@@ -67,8 +67,8 @@ describe('catalog drift', () => {
     }
   })
 
-  describe('secret redaction copied verbatim from display.ts', () => {
-    const original = () => read('../../../src/utils/display.ts')
+  describe('secret redaction copied verbatim from core/redact.ts', () => {
+    const original = () => read('../../../src/core/redact.ts')
     const copy = () => read('../src/shared/redact.ts')
 
     it('redact.ts contains redactSecrets verbatim', () => {

--- a/src/core/approvals.ts
+++ b/src/core/approvals.ts
@@ -19,7 +19,7 @@ import {
   runDir,
   withRunsLock,
 } from './runs.js'
-import { redactSecrets } from '../utils/display.js'
+import { redactSecrets } from './redact.js'
 
 export type ApprovalStatus = 'pending' | 'approved' | 'denied' | 'expired'
 export type ApprovalRisk = 'low' | 'medium' | 'high'

--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -1,6 +1,7 @@
-// Secret redaction copied from the unix package's src/core/redact.ts so `read`
-// output is scrubbed identically on both packages. catalog-drift.test.ts asserts
-// these match the originals so the patterns cannot silently diverge.
+// Secret redaction for everything persisted or surfaced from agent output.
+// Invariant: all user/model text fields are redacted before writing (see runs.ts).
+// packages/reevesagents-win/src/shared/redact.ts carries a verbatim copy,
+// enforced by its catalog-drift test.
 
 // Ordered: longer prefix patterns must come before shorter ones (e.g. sk-ant before sk-)
 const SECRET_PATTERNS = [

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -29,7 +29,7 @@ import type {
   RunViewStatus,
   TaskStatus,
 } from './types.js'
-import { redactSecrets } from '../utils/display.js'
+import { redactSecrets } from './redact.js'
 import { isProvider } from './providers.js'
 import * as tmux from './tmux.js'
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -36,7 +36,8 @@ import { loadPreset } from './store.js'
 import { buildCommand, detectAvailable, isProvider } from './providers.js'
 import { resolveWorkingDir, shellQuote } from './provider-launch.js'
 import { paneInSession, realDriver, STALE_WINDOW_ERROR, windowInSession, type RuntimeDriver } from './tmux.js'
-import { providerDisplayName, redactSecrets } from '../utils/display.js'
+import { redactSecrets } from './redact.js'
+import { providerDisplayName } from '../utils/display.js'
 
 export type { RuntimeDriver } from './tmux.js'
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
-// Core type definitions for agent-run state, presets, and TUI routing.
+// Core type definitions for agent-run state, presets, and config.
+// TUI routing types (ScreenName, RouterContextValue) live in tui/types.ts.
 
 export type Provider = 'cc' | 'codex' | 'opencode' | 'hermes' | 'kimi' | 'deepseek' | 'pi' | 'qwen' | 'aider'
 
@@ -19,38 +20,6 @@ export type RunStatus = 'running' | 'ended'
 export type RunViewStatus = RunStatus | 'stale'
 
 export type RunHistoryStatus = 'ended' | 'stale'
-
-export type ScreenName =
-  | 'Welcome'
-  | 'LanguageSelect'
-  | 'Runs'
-  | 'RunHistory'
-  | 'Run'
-  | 'RunAgents'
-  | 'RunOutput'
-  | 'RunStop'
-  | 'AgentDetail'
-  | 'AgentOutput'
-  | 'AgentTask'
-  | 'AgentKill'
-  | 'NewRun'
-  | 'NewRunBasics'
-  | 'NewRunRoot'
-  | 'NewRunWorkers'
-  | 'NewRunWorker'
-  | 'NewRunReview'
-  | 'NewRunStarting'
-  | 'AddWorker'
-  | 'Settings'
-  | 'AgentControl'
-  | 'Setup'
-  | 'Reference'
-  | 'Credits'
-  | 'Doctor'
-  | 'DoctorCheck'
-  | 'Approvals'
-  | 'Config'
-  | 'Presets'
 
 export interface Message {
   id: string
@@ -142,26 +111,6 @@ export interface CheckResult {
   name: string
   status: 'ok' | 'warn' | 'fail'
   detail: string
-}
-
-// Router context — browser-like screen history via push/pop/forward/replace.
-export interface RouterContextValue {
-  screen: ScreenName
-  push: (_screen: ScreenName) => void
-  pop: () => void
-  forward: () => void
-  replace: (_screen: ScreenName) => void
-  resetStack: (_screen: ScreenName, _base?: ScreenName[]) => void
-  selectedRunId: string | null
-  setSelectedRunId: (_runId: string | null) => void
-  selectedAgentId: string | null
-  setSelectedAgentId: (_agentId: string | null) => void
-  selectedCheckName: string | null
-  setSelectedCheckName: (_name: string | null) => void
-  selectedWorkerIdx: number | null
-  setSelectedWorkerIdx: (_idx: number | null) => void
-  canBack: boolean
-  canForward: boolean
 }
 
 // Global preferences; no auth, no keys.

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ export type {
   AuthMode,
   Effort,
   TaskStatus,
-  ScreenName,
   Config,
   GlobalConfig,
   Message,
@@ -54,5 +53,6 @@ export type {
   RunHistoryStatus,
   AgentRecord,
   CheckResult,
-  RouterContextValue,
 } from './core/types.js'
+
+export type { ScreenName, RouterContextValue } from './tui/types.js'

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -3,7 +3,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react'
 import { useApp } from 'ink'
-import type { ScreenName, RouterContextValue } from '../core/types.js'
+import type { ScreenName, RouterContextValue } from './types.js'
 
 import { ToastProvider } from './contexts/ToastContext.js'
 import { WizardProvider } from './contexts/WizardContext.js'

--- a/src/tui/screens/Welcome.tsx
+++ b/src/tui/screens/Welcome.tsx
@@ -13,7 +13,7 @@ import { Section, SectionEnd } from '../components/Section.js'
 import { Row } from '../components/Row.js'
 import { LayoutProvider } from '../components/LayoutContext.js'
 import { startWebFromTui } from '../../web/tui-launch.js'
-import type { ScreenName } from '../../core/types.js'
+import type { ScreenName } from '../types.js'
 import { useLanguage } from '../contexts/LanguageContext.js'
 
 function pickMascotVariant(columns: number): MascotVariant {

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -1,0 +1,54 @@
+// TUI routing types: the screen catalog and the router context shape.
+// These are surface types; domain/record types live in core/types.ts.
+
+export type ScreenName =
+  | 'Welcome'
+  | 'LanguageSelect'
+  | 'Runs'
+  | 'RunHistory'
+  | 'Run'
+  | 'RunAgents'
+  | 'RunOutput'
+  | 'RunStop'
+  | 'AgentDetail'
+  | 'AgentOutput'
+  | 'AgentTask'
+  | 'AgentKill'
+  | 'NewRun'
+  | 'NewRunBasics'
+  | 'NewRunRoot'
+  | 'NewRunWorkers'
+  | 'NewRunWorker'
+  | 'NewRunReview'
+  | 'NewRunStarting'
+  | 'AddWorker'
+  | 'Settings'
+  | 'AgentControl'
+  | 'Setup'
+  | 'Reference'
+  | 'Credits'
+  | 'Doctor'
+  | 'DoctorCheck'
+  | 'Approvals'
+  | 'Config'
+  | 'Presets'
+
+// Router context — browser-like screen history via push/pop/forward/replace.
+export interface RouterContextValue {
+  screen: ScreenName
+  push: (_screen: ScreenName) => void
+  pop: () => void
+  forward: () => void
+  replace: (_screen: ScreenName) => void
+  resetStack: (_screen: ScreenName, _base?: ScreenName[]) => void
+  selectedRunId: string | null
+  setSelectedRunId: (_runId: string | null) => void
+  selectedAgentId: string | null
+  setSelectedAgentId: (_agentId: string | null) => void
+  selectedCheckName: string | null
+  setSelectedCheckName: (_name: string | null) => void
+  selectedWorkerIdx: number | null
+  setSelectedWorkerIdx: (_idx: number | null) => void
+  canBack: boolean
+  canForward: boolean
+}

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -1,5 +1,6 @@
-// Display utilities: provider/model colors, color capability checks, secret redaction.
+// Display utilities: provider/model colors and labels.
 // Invariant: providerColor and modelColor always return a valid hex string or named color.
+// Secret redaction lives in core/redact.ts.
 
 import type { Provider } from '../core/types.js'
 import { PROVIDER_DEFS, PROVIDER_REGISTRY } from '../core/provider-registry.js'
@@ -58,18 +59,4 @@ export function modelBadgeLabel(model: string): string {
 function truncateLabel(label: string, max: number): string {
   if (label.length <= max) return label
   return `${label.slice(0, Math.max(1, max - 3))}...`
-}
-
-// Ordered: longer prefix patterns must come before shorter ones (e.g. sk-ant before sk-)
-const SECRET_PATTERNS = [
-  /sk-ant-[A-Za-z0-9\-_]{20,}/g,
-  /sk-[A-Za-z0-9\-_]{20,}/g,
-  /AIza[A-Za-z0-9\-_]{35}/g,
-  /gsk_[A-Za-z0-9\-_]{20,}/g,
-]
-
-export function redactSecrets(text: string): string {
-  let result = text
-  for (const pattern of SECRET_PATTERNS) result = result.replace(pattern, '[REDACTED]')
-  return result
 }

--- a/test/display.test.ts
+++ b/test/display.test.ts
@@ -77,45 +77,4 @@ describe('display utilities', () => {
       expect(modelBadgeLabel('deepseek-coder:33b')).toBe('deepseek-coder:33b')
     })
   })
-
-  describe('redactSecrets', () => {
-    it('replaces anthropic keys with [REDACTED]', async () => {
-      const { redactSecrets } = await import('../src/utils/display.js')
-      const input = 'auth: sk-ant-api03-abcdef1234567890abcdef1234567890 trailing'
-      expect(redactSecrets(input)).toBe('auth: [REDACTED] trailing')
-    })
-
-    it('replaces openai-shaped keys with [REDACTED]', async () => {
-      const { redactSecrets } = await import('../src/utils/display.js')
-      const input = 'token=sk-proj1234567890abcdefghij1234567890'
-      expect(redactSecrets(input)).toContain('[REDACTED]')
-      expect(redactSecrets(input)).not.toContain('sk-proj')
-    })
-
-    it('replaces google api keys with [REDACTED]', async () => {
-      const { redactSecrets } = await import('../src/utils/display.js')
-      // pattern requires exactly 35 chars after AIza
-      const input = 'key=AIzaSyA1234567890abcdefghijklmnopqrstuv'
-      expect(redactSecrets(input)).toBe('key=[REDACTED]')
-    })
-
-    it('replaces groq keys with [REDACTED]', async () => {
-      const { redactSecrets } = await import('../src/utils/display.js')
-      const input = 'GROQ=gsk_abcdefghij1234567890abcdef'
-      expect(redactSecrets(input)).toContain('[REDACTED]')
-    })
-
-    it('leaves clean text alone', async () => {
-      const { redactSecrets } = await import('../src/utils/display.js')
-      const input = 'just a normal task description'
-      expect(redactSecrets(input)).toBe(input)
-    })
-
-    it('is idempotent on already-redacted text', async () => {
-      const { redactSecrets } = await import('../src/utils/display.js')
-      const once = redactSecrets('sk-ant-abcdefghij1234567890abcd')
-      const twice = redactSecrets(once)
-      expect(twice).toBe(once)
-    })
-  })
 })

--- a/test/redact.test.ts
+++ b/test/redact.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+
+describe('redactSecrets', () => {
+  it('replaces anthropic keys with [REDACTED]', async () => {
+    const { redactSecrets } = await import('../src/core/redact.js')
+    const input = 'auth: sk-ant-api03-abcdef1234567890abcdef1234567890 trailing'
+    expect(redactSecrets(input)).toBe('auth: [REDACTED] trailing')
+  })
+
+  it('replaces openai-shaped keys with [REDACTED]', async () => {
+    const { redactSecrets } = await import('../src/core/redact.js')
+    const input = 'token=sk-proj1234567890abcdefghij1234567890'
+    expect(redactSecrets(input)).toContain('[REDACTED]')
+    expect(redactSecrets(input)).not.toContain('sk-proj')
+  })
+
+  it('replaces google api keys with [REDACTED]', async () => {
+    const { redactSecrets } = await import('../src/core/redact.js')
+    // pattern requires exactly 35 chars after AIza
+    const input = 'key=AIzaSyA1234567890abcdefghijklmnopqrstuv'
+    expect(redactSecrets(input)).toBe('key=[REDACTED]')
+  })
+
+  it('replaces groq keys with [REDACTED]', async () => {
+    const { redactSecrets } = await import('../src/core/redact.js')
+    const input = 'GROQ=gsk_abcdefghij1234567890abcdef'
+    expect(redactSecrets(input)).toContain('[REDACTED]')
+  })
+
+  it('leaves clean text alone', async () => {
+    const { redactSecrets } = await import('../src/core/redact.js')
+    const input = 'just a normal task description'
+    expect(redactSecrets(input)).toBe(input)
+  })
+
+  it('is idempotent on already-redacted text', async () => {
+    const { redactSecrets } = await import('../src/core/redact.js')
+    const once = redactSecrets('sk-ant-abcdefghij1234567890abcd')
+    const twice = redactSecrets(once)
+    expect(twice).toBe(once)
+  })
+})

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { nextHistoryOnPush, nextHistoryOnReset } from '../src/tui/router.js'
 import { Router } from '../src/tui/router.js'
-import type { ScreenName } from '../src/core/types.js'
+import type { ScreenName } from '../src/tui/types.js'
 
 function state(entries: ScreenName[], index: number) {
   return { entries, index }

--- a/test/screens/Agent-Kill.test.tsx
+++ b/test/screens/Agent-Kill.test.tsx
@@ -9,7 +9,8 @@ import { AgentKill } from '../../src/tui/screens/run/AgentKill.js'
 import { ToastProvider } from '../../src/tui/contexts/ToastContext.js'
 import * as runsState from '../../src/core/runs.js'
 import * as runtime from '../../src/core/runtime.js'
-import type { AgentRecord, RouterContextValue, RunRecord } from '../../src/core/types.js'
+import type { AgentRecord, RunRecord } from '../../src/core/types.js'
+import type { RouterContextValue } from '../../src/tui/types.js'
 
 const waitForInput = () => new Promise(resolve => setTimeout(resolve, 75))
 

--- a/test/screens/Agent-Output.test.tsx
+++ b/test/screens/Agent-Output.test.tsx
@@ -8,7 +8,8 @@ import { AgentOutput } from '../../src/tui/screens/run/AgentOutput.js'
 import { ToastProvider } from '../../src/tui/contexts/ToastContext.js'
 import * as runsState from '../../src/core/runs.js'
 import * as runtime from '../../src/core/runtime.js'
-import type { RunRecord, AgentRecord, RouterContextValue } from '../../src/core/types.js'
+import type { RunRecord, AgentRecord } from '../../src/core/types.js'
+import type { RouterContextValue } from '../../src/tui/types.js'
 
 const waitForInput = () => vi.advanceTimersByTimeAsync(75)
 

--- a/test/screens/AgentDetail.test.tsx
+++ b/test/screens/AgentDetail.test.tsx
@@ -8,7 +8,8 @@ import { AgentDetail } from '../../src/tui/screens/AgentDetail.js'
 import { ToastProvider } from '../../src/tui/contexts/ToastContext.js'
 import * as runsState from '../../src/core/runs.js'
 import * as runtime from '../../src/core/runtime.js'
-import type { RunRecord, AgentRecord, RouterContextValue } from '../../src/core/types.js'
+import type { RunRecord, AgentRecord } from '../../src/core/types.js'
+import type { RouterContextValue } from '../../src/tui/types.js'
 
 const waitForInput = () => new Promise(resolve => setTimeout(resolve, 75))
 

--- a/test/screens/active-scenario-walk.test.tsx
+++ b/test/screens/active-scenario-walk.test.tsx
@@ -31,12 +31,8 @@ import { Settings } from '../../src/tui/screens/Settings.js'
 import { Reference } from '../../src/tui/screens/Reference.js'
 import { Credits } from '../../src/tui/screens/Credits.js'
 import { writeAgent, writeRun } from '../../src/core/runs.js'
-import type {
-  AgentRecord,
-  RouterContextValue,
-  RunRecord,
-  ScreenName,
-} from '../../src/core/types.js'
+import type { AgentRecord, RunRecord } from '../../src/core/types.js'
+import type { RouterContextValue, ScreenName } from '../../src/tui/types.js'
 
 vi.mock('../../src/core/runs.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/core/runs.js')>('../../src/core/runs.js')

--- a/test/screens/responsive-layout.test.tsx
+++ b/test/screens/responsive-layout.test.tsx
@@ -16,7 +16,8 @@ import { RouterContext } from '../../src/tui/router.js'
 import { ToastProvider } from '../../src/tui/contexts/ToastContext.js'
 import { WizardProvider } from '../../src/tui/contexts/WizardContext.js'
 import { writeAgent, writeRun } from '../../src/core/runs.js'
-import type { AgentRecord, RouterContextValue, RunRecord } from '../../src/core/types.js'
+import type { AgentRecord, RunRecord } from '../../src/core/types.js'
+import type { RouterContextValue } from '../../src/tui/types.js'
 
 const viewport = vi.hoisted(() => ({
   current: { columns: 100, rows: 24 },

--- a/test/screens/run/AddWorker.test.tsx
+++ b/test/screens/run/AddWorker.test.tsx
@@ -9,7 +9,8 @@ import { RouterContext } from '../../../src/tui/router.js'
 import { ToastProvider } from '../../../src/tui/contexts/ToastContext.js'
 import { WorkerDraftProvider } from '../../../src/tui/contexts/WorkerDraftContext.js'
 import { writeRun } from '../../../src/core/runs.js'
-import type { RouterContextValue, RunRecord } from '../../../src/core/types.js'
+import type { RunRecord } from '../../../src/core/types.js'
+import type { RouterContextValue } from '../../../src/tui/types.js'
 import * as RuntimeModule from '../../../src/core/runtime.js'
 
 vi.mock('../../../src/core/runtime.js', async () => {

--- a/test/screens/walk-snapshot.test.tsx
+++ b/test/screens/walk-snapshot.test.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { describe, expect, it } from 'vitest'
 import { render } from 'ink-testing-library'
 import { Router } from '../../src/tui/router.js'
-import type { ScreenName } from '../../src/core/types.js'
+import type { ScreenName } from '../../src/tui/types.js'
 
 const SCREENS: ScreenName[] = [
   'Welcome',

--- a/test/setup-screen.test.tsx
+++ b/test/setup-screen.test.tsx
@@ -4,7 +4,7 @@ import { render } from 'ink-testing-library'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import type { ScreenName } from '../src/core/types.js'
+import type { ScreenName } from '../src/tui/types.js'
 
 // Mock child_process so the setup screen's environment probe (which / tmux -V /
 // mcp list) is fast and deterministic and never runs a real CLI.


### PR DESCRIPTION
## Summary

- `core/types.ts` mixed domain records with TUI routing types, so `ScreenName`/`RouterContextValue` leaked into the public API and into the Windows package's synced `shared/types.ts` (a package with no TUI). They now live in `src/tui/types.ts`; `index.ts` re-exports them from the new home, so the public surface is unchanged. After `sync:shared` the win copy drops 55 lines of TUI types.
- `redactSecrets` moved from `utils/display.ts` to `src/core/redact.ts`: it is a persistence security invariant, not a display concern, and the old home made the JSON store depend transitively on the Ink color palette. The win `catalog-drift.test.ts` now reads `core/redact.ts` for its verbatim checks; the redaction tests moved to `test/redact.test.ts`.
- No behavior change. Test counts identical: root 741 (93 files, +1 from the test split), win 51. Stage B of the agreed restructuring program (after #21).

## Scope

- [x] Stable CLI/TUI
- [x] Web UI beta
- [ ] Docs or release packaging

## Checks

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm smoke:cli`
- [x] `pnpm check:package`
- [ ] `pnpm check:install-matrix`

## Notes

- Target branch: master
- Risk: low; type-only moves plus one pure function relocation, win package re-synced and its drift test updated.