### PR TITLE
refactor(repo): hygiene pass closing the restructuring program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@ specs/
 assets/
 !docs/assets/
 !docs/assets/**
-!src/brand/assets/
-!src/brand/assets/duck.svg
+!src/tui/brand/assets/
+!src/tui/brand/assets/duck.svg
 .playwright-mcp/
 .aider*
 reevesagents-latestnotes.md

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import tsParser from '@typescript-eslint/parser'
 export default [
   js.configs.recommended,
   {
-    files: ['src/**/*.{ts,tsx}', 'test/**/*.ts'],
+    files: ['src/**/*.{ts,tsx}', 'test/**/*.{ts,tsx}'],
     rules: {
       'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'no-console': 'off',

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -1,5 +1,8 @@
 // Screen history router for the v1 visible-menu TUI.
 // Push/pop manage pages; selected run/agent ids live beside routing state.
+// Screen file convention: a screen file is named exactly after its export;
+// multi-screen route families (screens/run/, screens/newrun/) get a folder;
+// single-screen routes stay flat in screens/.
 
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react'
 import { useApp } from 'ink'

--- a/src/web/client-shell.ts
+++ b/src/web/client-shell.ts
@@ -1,7 +1,7 @@
-// Inline placeholder page served by the web UI in the scaffold phase.
-// Input: none. Output: a self-contained HTML string (no external assets).
-// Invariant: this is a viewer over /api/state only. The interactive xterm.js
-// client replaces this page once the browser build lands; nothing here writes state.
+// Inline fallback page served when the built web client assets (dist/web) are
+// missing, e.g. a CLI/TUI-only install. Input: none. Output: a self-contained
+// HTML string (no external assets).
+// Invariant: this is a viewer over /api/state only; nothing here writes state.
 
 const PALETTE = {
   bg: '#15191f',

--- a/test/components/Detail.test.tsx
+++ b/test/components/Detail.test.tsx
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 import { render } from 'ink-testing-library'
 import { Text } from 'ink'
 import { Detail } from '../../src/tui/components/Detail.js'
-import { colors } from '../../src/tui/utils/tokens.js'
 
 describe('Detail', () => {
   it('renders without title', () => {

--- a/test/components/Dialog.test.tsx
+++ b/test/components/Dialog.test.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { render } from 'ink-testing-library'
 import { expect, it, describe, vi } from 'vitest'
 import { Dialog } from '../../src/tui/components/Dialog.js'
-import { colors } from '../../src/tui/utils/tokens.js'
 
 describe('Dialog', () => {
   it('renders title and body', () => {

--- a/test/components/TextField.test.tsx
+++ b/test/components/TextField.test.tsx
@@ -279,7 +279,6 @@ describe('TextField', () => {
         onChange={onChange}
       />
     )
-    const frame = lastFrame()
     // Should not have unnecessary asterisks (may have spaces instead)
     const content = lastFrame()
     expect(content).toContain('Name')

--- a/test/screens/AgentKill.test.tsx
+++ b/test/screens/AgentKill.test.tsx
@@ -2,7 +2,7 @@
 // Note: selectedAgentId routing requires full app context, so we test error handling.
 
 import React from 'react'
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { render } from 'ink-testing-library'
 import { Router, RouterContext } from '../../src/tui/router.js'
 import { AgentKill } from '../../src/tui/screens/run/AgentKill.js'

--- a/test/screens/AgentTask.test.tsx
+++ b/test/screens/AgentTask.test.tsx
@@ -2,7 +2,7 @@
 // Note: selectedAgentId routing requires full app context, so we test error handling.
 
 import React from 'react'
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { render } from 'ink-testing-library'
 import { Router } from '../../src/tui/router.js'
 import * as runsState from '../../src/core/runs.js'

--- a/test/screens/Run.test.tsx
+++ b/test/screens/Run.test.tsx
@@ -224,7 +224,7 @@ describe('Run hub screen', () => {
       throw new Error('not found')
     })
 
-    const { lastFrame, unmount } = render(
+    const { unmount } = render(
       <Router initialScreen="Runs" />
     )
     unmount()

--- a/test/screens/RunAgents.test.tsx
+++ b/test/screens/RunAgents.test.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'ink-testing-library'
 import { Router } from '../../src/tui/router.js'
-import * as runsState from '../../src/core/runs.js'
 import type { RunRecord, AgentRecord } from '../../src/core/types.js'
 
 vi.mock('../../src/core/runs.js', async () => {

--- a/test/screens/Runs.test.tsx
+++ b/test/screens/Runs.test.tsx
@@ -3,7 +3,6 @@
 import React from 'react'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'ink-testing-library'
-import { Runs } from '../../src/tui/screens/Runs.js'
 import { Router } from '../../src/tui/router.js'
 import * as runsState from '../../src/core/runs.js'
 

--- a/test/screens/active-scenario-walk.test.tsx
+++ b/test/screens/active-scenario-walk.test.tsx
@@ -219,7 +219,6 @@ describe('active scenario walk', () => {
         </Harness>
       )
       const frame = lastFrame() ?? '(empty frame)'
-      // eslint-disable-next-line no-console
       console.log(`\n========== ${scenario.name} ==========\n${frame}\n========================\n`)
       expect(frame.length).toBeGreaterThan(0)
       unmount()

--- a/test/screens/walk-snapshot.test.tsx
+++ b/test/screens/walk-snapshot.test.tsx
@@ -26,7 +26,6 @@ describe('screen walk', () => {
       const { lastFrame, unmount } = render(<Router initialScreen={screen} />)
       const frame = lastFrame() ?? '(empty frame)'
       // Output goes through vitest's stdout when reporter is verbose.
-      // eslint-disable-next-line no-console
       console.log(`\n========== ${screen} ==========\n${frame}\n========================\n`)
       expect(frame.length).toBeGreaterThan(0)
       unmount()


### PR DESCRIPTION
## Summary

- `.gitignore`: fix stale brand-asset negations still pointing at pre-reorg `src/brand/assets/`.
- eslint: lint `test/**/*.tsx` too (30+ tsx test files were previously unlinted); fix the 8 unused-import/variable errors and 2 dead eslint-disable directives that surfaced.
- `client-shell.ts`: header claimed the browser client had not landed; it is the live fallback for installs without `dist/web` assets.
- `router.tsx`: state the screen file-naming convention in the header (named in #26's commit message but the comment had not shipped).
- Program close-out verification: full `verify:release` green (incl. install-matrix), `--help` byte-identical to the pre-program baseline, live spawn/send/peek/kill round-trip on the built CLI, win package green. Final stage after #21, #24, #25, #26.

## Scope

- [x] Stable CLI/TUI
- [x] Web UI beta
- [ ] Docs or release packaging

## Checks

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm smoke:cli`
- [x] `pnpm check:package`
- [x] `pnpm check:install-matrix`

## Notes

- Target branch: master
- Risk: minimal; comment/config fixes and unused-symbol removals in tests.