### PR TITLE
ci: self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: renovate
+
+# Self-hosted Renovate. Runs the Renovate bot as an Actions job (no Mend GitHub
+# App needed) against this repo, reading renovate.json for the rules. Uses the
+# CI_PAT classic PAT so its update PRs get CI and can auto-merge; GITHUB_TOKEN
+# would not trigger downstream workflow runs.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1,3,5' # Mon/Wed/Fri 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: renovatebot/github-action@v46.1.21
+        with:
+          token: ${{ secrets.CI_PAT }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: info


### PR DESCRIPTION
The Mend Renovate app never activated on the repo (no onboarding PR/branch/dashboard a day after install), and a GitHub App can't be installed headlessly. This runs Renovate as a scheduled Actions job instead, reading the existing `renovate.json`.

- Schedule: Mon/Wed/Fri 06:00 UTC + `workflow_dispatch` for on-demand runs.
- Token: reuses `CI_PAT` (classic PAT, repo+workflow) so update PRs get CI and can auto-merge; `GITHUB_TOKEN` would not trigger downstream runs.
- Behaviour comes from `renovate.json` (automerge minor/patch after CI, majors held on the dependency dashboard).