### PR TITLE
fix(core): stop leaking tmux sessions and agent processes across the run lifecycle

### DIFF
--- a/packages/reevesagents-win/src/shared/types.ts
+++ b/packages/reevesagents-win/src/shared/types.ts
@@ -73,6 +73,7 @@ export interface AgentRecord {
   tmux_session: string
   tmux_window_id: string
   tmux_pane_id: string
+  pane_pid?: number | null  // pane's foreground pid at spawn, for SIGTERM/SIGKILL escalation
   rc_enabled: boolean
   permissions: Permissions
   headless?: boolean        // true for add-on caller records with no tmux window

--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -1,0 +1,42 @@
+// Process teardown helpers. kill-window/kill-session only SIGHUP the pane's
+// foreground process; a CLI that ignores SIGHUP or keeps detached children
+// outlives its window. These helpers escalate to SIGTERM then SIGKILL on the
+// pane's process group. Callers must only escalate when tmux confirmed the
+// pane's window existed moments ago (a successful kill-window/kill-session):
+// a stale record's pane_pid can name an unrelated reused process.
+
+function sleepSync(ms: number): void {
+  const buffer = new SharedArrayBuffer(4)
+  const view = new Int32Array(buffer)
+  Atomics.wait(view, 0, 0, ms)
+}
+
+export function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as { code?: string }).code === 'EPERM'
+  }
+}
+
+// tmux panes are session leaders, so the pane pid is also its process group id;
+// signal the group to reach detached children, falling back to the bare pid.
+function signalProcessGroup(pid: number, signal: 'SIGTERM' | 'SIGKILL'): void {
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    try { process.kill(pid, signal) } catch { /* already gone */ }
+  }
+}
+
+const KILL_GRACE_MS = 400
+
+export function reapPaneProcess(pid: number | null | undefined): void {
+  if (!pid || pid <= 0 || !processAlive(pid)) return
+  sleepSync(KILL_GRACE_MS)
+  if (!processAlive(pid)) return
+  signalProcessGroup(pid, 'SIGTERM')
+  sleepSync(KILL_GRACE_MS)
+  if (processAlive(pid)) signalProcessGroup(pid, 'SIGKILL')
+}

--- a/src/core/reaper.ts
+++ b/src/core/reaper.ts
@@ -12,6 +12,7 @@
 import { loadConfig } from './config.js'
 import { listAgents, listRuns, nowMs } from './runs.js'
 import {
+  allWindowIds as tmuxAllWindowIds,
   listSessions as tmuxListSessions,
   killSession as tmuxKillSession,
   sessionAttached as tmuxSessionAttached,
@@ -57,12 +58,23 @@ export function sweepAgents(options: SweepOptions = {}): { reaped: ReapedAgent[]
   const now = options.now ?? nowMs
   const maxLifetimeMs = options.maxLifetimeMs ?? loadConfig().global.max_lifetime_ms
 
+  const candidates = listAgents().filter(agent => !agent.ended_at && !agent.headless)
+
+  // Batch path (no injected probe): one server-wide window enumeration instead
+  // of a tmux spawn per agent per sweep. A miss is confirmed with a fresh probe
+  // so a window born after the enumeration is never misjudged as gone.
+  const batchWindows = !options.targetExists && candidates.some(agent => agent.tmux_window_id)
+    ? tmuxAllWindowIds()
+    : null
+  const probe = batchWindows
+    ? (id: string, session: string): boolean => batchWindows.has(`${session}\0${id}`) || targetExists(id, session)
+    : targetExists
+
   const reaped: ReapedAgent[] = []
-  for (const agent of listAgents()) {
-    if (agent.ended_at || agent.headless) continue
+  for (const agent of candidates) {
     const ageMs = now() - new Date(agent.started_at).getTime()
     let reason: ReapReason | null = null
-    if (agent.tmux_window_id && !targetExists(agent.tmux_window_id, agent.tmux_session)) {
+    if (agent.tmux_window_id && !probe(agent.tmux_window_id, agent.tmux_session)) {
       reason = 'window-gone'
     } else if (maxLifetimeMs > 0 && ageMs > maxLifetimeMs) {
       reason = 'lifetime-exceeded'

--- a/src/core/reaper.ts
+++ b/src/core/reaper.ts
@@ -10,8 +10,19 @@
 // autoCleanupRuns knows nothing about.
 
 import { loadConfig } from './config.js'
-import { listAgents, nowMs } from './runs.js'
-import { targetExists as tmuxTargetExists, tmuxAvailable, type RuntimeDriver } from './tmux.js'
+import { listAgents, listRuns, nowMs } from './runs.js'
+import {
+  listSessions as tmuxListSessions,
+  killSession as tmuxKillSession,
+  sessionAttached as tmuxSessionAttached,
+  RUN_SESSION_PATTERN,
+  sessionInGroup,
+  targetExists as tmuxTargetExists,
+  tmuxAvailable,
+  VIEWER_SESSION_PATTERN,
+  type RuntimeDriver,
+  type TmuxSessionInfo,
+} from './tmux.js'
 import { killAgent } from './runtime.js'
 
 export type ReapReason = 'window-gone' | 'lifetime-exceeded'
@@ -73,6 +84,77 @@ export function sweepAgents(options: SweepOptions = {}): { reaped: ReapedAgent[]
   return { reaped }
 }
 
+// Orphan sessions are tmux sessions that no live record owns: run sessions left
+// behind by a crash between new-session and the record write (or by an archive
+// that predates kill-before-archive), and web viewer sessions whose run session
+// is gone. Record-driven cleanup can never see these, so enumerate instead.
+// Safety rules:
+// - Attached sessions are spared, re-probed right before the kill (a human may
+//   have attached since the enumeration).
+// - Sessions younger than ORPHAN_MIN_AGE_SEC are spared: a startRun in another
+//   process creates the session before its record exists, and the sweep must not
+//   kill a run that is still starting.
+// - Ownership is judged against this process's registry only (stateRoot()); two
+//   registries sharing one tmux server is unsupported — a sweep would see the
+//   other registry's sessions as orphans.
+export interface OrphanSweepOptions {
+  listSessions?: () => TmuxSessionInfo[]
+  killSession?: (_session: string) => void
+  sessionAttached?: (_session: string) => boolean
+  tmuxAvailable?: () => boolean
+  now?: () => number
+  // Manual sweeps (CLI/MCP reap) set this: the grace exists to protect runs
+  // mid-start from *background* sweeps; an explicit user sweep may ignore it.
+  ignoreGrace?: boolean
+}
+
+// Sessions younger than this are still being set up by their owning process.
+const ORPHAN_MIN_AGE_SEC = 60
+
+export function sweepOrphanSessions(options: OrphanSweepOptions = {}): { killed: string[] } {
+  const haveTmux = options.listSessions ? true : (options.tmuxAvailable ?? tmuxAvailable)()
+  if (!haveTmux) return { killed: [] }
+  const sessions = (options.listSessions ?? tmuxListSessions)()
+  const killSession = options.killSession ?? tmuxKillSession
+  const sessionAttached = options.sessionAttached ?? tmuxSessionAttached
+  const nowSec = ((options.now ?? nowMs)()) / 1000
+  const liveRunSessions = new Set(listRuns().map(run => run.tmux_session))
+  const killed: string[] = []
+  for (const info of sessions) {
+    if (info.attached) continue
+    if (!options.ignoreGrace && info.createdSec > 0 && nowSec - info.createdSec < ORPHAN_MIN_AGE_SEC) continue
+    let orphan = false
+    if (RUN_SESSION_PATTERN.test(info.name)) {
+      orphan = !liveRunSessions.has(info.name)
+    } else if (VIEWER_SESSION_PATTERN.test(info.name)) {
+      // A viewer is only legitimate while its group still holds a recorded run session.
+      orphan = ![...liveRunSessions].some(s => sessionInGroup(info, s))
+    }
+    if (!orphan) continue
+    if (sessionAttached(info.name)) continue
+    try {
+      killSession(info.name)
+      killed.push(info.name)
+    } catch {
+      // session disappeared mid-sweep
+    }
+  }
+  return { killed }
+}
+
+// Orphan enumeration is one list-sessions call, so it can share the sweep cadence.
+let lastOrphanSweepAt = 0
+
+export function sweepOrphanSessionsThrottled(
+  minIntervalMs = 15_000,
+  options: OrphanSweepOptions = {},
+): { killed: string[]; swept: boolean } {
+  const now = nowMs()
+  if (lastOrphanSweepAt !== 0 && now - lastOrphanSweepAt < minIntervalMs) return { killed: [], swept: false }
+  lastOrphanSweepAt = now
+  return { ...sweepOrphanSessions(options), swept: true }
+}
+
 // Throttle state for the periodic surfaces (TUI refresh, web SSE tick, MCP list).
 // They tick every couple of seconds; without this each tick would spawn a tmux
 // probe per windowed agent. Module-level is correct: these hosts are long-lived
@@ -94,4 +176,5 @@ export function sweepAgentsThrottled(
 // Test seam: forget the last sweep time so the next throttled call runs immediately.
 export function resetSweepThrottle(): void {
   lastSweepAt = 0
+  lastOrphanSweepAt = 0
 }

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -532,9 +532,29 @@ export function autoCleanupRuns(options: AutoCleanupOptions = {}): { removed: st
   const archived: string[] = []
   const runs = listRunsUnlocked(true)
 
+  // Batch path (no injected checks): one server-wide enumeration instead of a
+  // tmux spawn per run per tick. A stale verdict is always confirmed with fresh
+  // per-run probes, so a window born after the enumeration is never misjudged.
+  const useBatch = haveTmux && !options.sessionExists && !options.targetExists && runs.length > 0
+  const batchWindows = useBatch ? tmux.allWindowIds() : null
+  const batchSessions = useBatch ? new Set(tmux.listSessions().map(info => info.name)) : null
+  const batchTargetExists = batchWindows
+    ? (target: string, session: string): boolean => batchWindows.has(`${session}\0${target}`)
+    : undefined
+  const batchSessionExists = batchSessions
+    ? (session: string): boolean => batchSessions.has(session)
+    : undefined
+
   for (const run of runs) {
     const isEnded = isRunEnded(run)
-    const isStale = !isEnded && haveTmux && !runHasLiveTmuxTarget(run, { sessionExists, targetExists })
+    let isStale = false
+    if (!isEnded && haveTmux) {
+      const looksDead = batchTargetExists && batchSessionExists
+        ? !runHasLiveTmuxTarget(run, { sessionExists: batchSessionExists, targetExists: batchTargetExists })
+        : !runHasLiveTmuxTarget(run, { sessionExists, targetExists })
+      // Confirm with fresh probes before killing and archiving a live-looking miss.
+      isStale = looksDead && !runHasLiveTmuxTarget(run, batchTargetExists ? {} : { sessionExists, targetExists })
+    }
     if (!isEnded && !isStale) continue
     try {
       if (isStale) {

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -31,6 +31,7 @@ import type {
 } from './types.js'
 import { redactSecrets } from './redact.js'
 import { isProvider } from './providers.js'
+import { reapPaneProcess } from './process.js'
 import * as tmux from './tmux.js'
 
 export function stateRoot(): string {
@@ -207,6 +208,7 @@ function normalizeAgent(raw: Record<string, unknown>): AgentRecord {
     tmux_session: asString(raw.tmux_session),
     tmux_window_id: asString(raw.tmux_window_id),
     tmux_pane_id: asString(raw.tmux_pane_id),
+    pane_pid: typeof raw.pane_pid === 'number' && raw.pane_pid > 0 ? raw.pane_pid : null,
     rc_enabled: typeof raw.rc_enabled === 'boolean' ? raw.rc_enabled : false,
     permissions: normalizePermissions(raw.permissions),
     headless: raw.headless === true,
@@ -472,10 +474,6 @@ export function findAgent(agentId: string): AgentRecord {
   throw new Error(`Agent not found: ${agentId}`)
 }
 
-export function heartbeatAgent(runId: string, agentId: string): void {
-  updateAgent(runId, agentId, { last_seen: nowMs() })
-}
-
 export function appendAgentInbox(runId: string, agentId: string, message: Message): void {
   withRunsLock(() => {
     const agent = readAgentUnlocked(runId, agentId)
@@ -497,6 +495,8 @@ export function readAgentInbox(runId: string, agentId: string): Message[] {
 export interface AutoCleanupOptions {
   sessionExists?: (_session: string) => boolean
   targetExists?: (_target: string, _session: string) => boolean
+  killSession?: (_session: string) => void
+  killViewers?: (_runSession: string) => void
   tmuxAvailable?: () => boolean
   cleanStale?: boolean
 }
@@ -515,9 +515,14 @@ export function runHasLiveTmuxTarget(run: RunRecord, options: AutoCleanupOptions
 // Runs refresh tick. If tmux is not installed at all, only ended runs are
 // cleaned (the stale check is skipped) so a missing-tmux environment never
 // nukes the user's run records. Per-run failures are swallowed.
+// A stale run's tmux session (pinned open by the linked reeves anchor window)
+// and its grouped web viewers are killed before archiving, so record removal
+// never leaves tmux state behind.
 export function autoCleanupRuns(options: AutoCleanupOptions = {}): { removed: string[]; archived: string[] } {
   const sessionExists = options.sessionExists ?? tmux.sessionExists
   const targetExists = options.targetExists ?? tmux.targetExists
+  const killSession = options.killSession ?? tmux.killSession
+  const killViewers = options.killViewers ?? tmux.killGroupedViewers
   // If the caller injected tmux checks (test drivers), treat tmux as available and skip the real probe.
   const tmuxAvailable = options.sessionExists || options.targetExists
     ? () => true
@@ -526,11 +531,26 @@ export function autoCleanupRuns(options: AutoCleanupOptions = {}): { removed: st
   const removed: string[] = []
   const archived: string[] = []
   const runs = listRunsUnlocked(true)
+
   for (const run of runs) {
     const isEnded = isRunEnded(run)
     const isStale = !isEnded && haveTmux && !runHasLiveTmuxTarget(run, { sessionExists, targetExists })
     if (!isEnded && !isStale) continue
     try {
+      if (isStale) {
+        // Viewers stay identifiable by group name even after the run session is
+        // gone, so kill them unconditionally; the session kill needs it to exist.
+        killViewers(run.tmux_session)
+        if (sessionExists(run.tmux_session)) {
+          killSession(run.tmux_session)
+          // The session was confirmed present seconds ago, so its recorded pane
+          // pids are safe to escalate on: SIGHUP-resistant CLIs must not outlive
+          // the archive that is about to delete their records.
+          for (const agent of listAgents(run.id)) {
+            if (!agent.ended_at && agent.pane_pid) reapPaneProcess(agent.pane_pid)
+          }
+        }
+      }
       const record = archiveAndRemoveRun(run.id, isStale ? 'stale' : 'ended')
       removed.push(run.id)
       archived.push(record.id)

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -35,7 +35,8 @@ import { loadConfig } from './config.js'
 import { loadPreset } from './store.js'
 import { buildCommand, detectAvailable, isProvider } from './providers.js'
 import { resolveWorkingDir, shellQuote } from './provider-launch.js'
-import { paneInSession, realDriver, STALE_WINDOW_ERROR, windowInSession, type RuntimeDriver } from './tmux.js'
+import { paneInSession, realDriver, sessionInGroup, STALE_WINDOW_ERROR, VIEWER_SESSION_PATTERN, windowInSession, type RuntimeDriver } from './tmux.js'
+import { reapPaneProcess } from './process.js'
 import { redactSecrets } from './redact.js'
 import { providerDisplayName } from '../utils/display.js'
 
@@ -78,6 +79,7 @@ export interface RuntimeOptions {
 export interface TmuxIds {
   windowId: string
   paneId: string
+  panePid?: number
 }
 
 export const ALLOWED_KEYS = [
@@ -104,6 +106,23 @@ function sleepSync(ms: number): void {
   const buffer = new SharedArrayBuffer(4)
   const view = new Int32Array(buffer)
   Atomics.wait(view, 0, 0, ms)
+}
+
+// Web viewer sessions (reevesweb_*) are grouped with the run session, so killing
+// the run session alone leaves them holding the run's windows and processes.
+function killViewerSessions(driver: RuntimeDriver, runSession: string): void {
+  let rows: string
+  try {
+    rows = driver.tmux(['list-sessions', '-F', '#{session_name}\t#{session_group}\t#{session_group_list}'])
+  } catch {
+    return
+  }
+  for (const row of rows.split('\n')) {
+    const [name = '', group = '', groupList = ''] = row.trim().split('\t')
+    if (!VIEWER_SESSION_PATTERN.test(name)) continue
+    if (!sessionInGroup({ group, groupList: groupList.split(',').filter(Boolean) }, runSession)) continue
+    try { driver.tmux(['kill-session', '-t', `=${name}`]) } catch { /* already gone */ }
+  }
 }
 
 function waitAfterPaste(driver: RuntimeDriver): void {
@@ -157,11 +176,12 @@ function childProcessOutput(err: unknown): string {
 }
 
 export function parseTmuxIds(output: string): TmuxIds {
-  const [windowId, paneId] = output.trim().split(/\s+/)
+  const [windowId, paneId, panePidRaw] = output.trim().split(/\s+/)
   if (!windowId?.startsWith('@') || !paneId?.startsWith('%')) {
     throw new Error(`Could not parse tmux ids from: ${output}`)
   }
-  return { windowId, paneId }
+  const panePid = panePidRaw === undefined ? undefined : Number.parseInt(panePidRaw, 10)
+  return { windowId, paneId, panePid: Number.isFinite(panePid) && panePid! > 0 ? panePid : undefined }
 }
 
 function readDisplayIds(driver: RuntimeDriver, target?: string): TmuxIds | null {
@@ -291,6 +311,7 @@ function newAgentRecord(
     tmux_session: tmuxSession,
     tmux_window_id: ids.windowId,
     tmux_pane_id: ids.paneId,
+    pane_pid: ids.panePid ?? null,
     rc_enabled: false,
     permissions,
     inbox: [],
@@ -320,7 +341,7 @@ function createAgentWindow(
     '-d',
     '-P',
     '-F',
-    '#{window_id} #{pane_id}',
+    '#{window_id} #{pane_id} #{pane_pid}',
     '-t',
     `${tmuxSession}:`,
     '-n',
@@ -626,13 +647,18 @@ export function killAgent(agentId: string, options: RuntimeOptions = {}): AgentR
   // Only kill the window when the stored id still belongs to this run's session; a
   // stale id (server restart) would name an unrelated window. A failed check means
   // the window is already gone, so the record teardown below proceeds either way.
-  if (windowInSession(driver, agent.tmux_session, agent.tmux_window_id)) {
+  // Process escalation is gated on the same check: without a fresh confirmation
+  // the pane was really ours, a stale pane_pid could name a reused stranger pid.
+  const hadWindow = windowInSession(driver, agent.tmux_session, agent.tmux_window_id)
+  if (hadWindow) {
     try {
       driver.tmux(['kill-window', '-t', agent.tmux_window_id])
     } catch {
       // already gone
     }
+    reapPaneProcess(agent.pane_pid)
   }
+  lastPasteAtByPane.delete(agent.tmux_pane_id)
   const endedAt = nowIso()
   updateAgent(agent.run_id, agent.id, { ended_at: endedAt, task_status: 'done' })
   const updatedAgent = readAgent(agent.run_id, agent.id)
@@ -641,6 +667,7 @@ export function killAgent(agentId: string, options: RuntimeOptions = {}): AgentR
     // Same guard as stopRun: never kill a session the run shares with the reeves TUI.
     const runOwnsSession = !!run.reeves_session && run.reeves_session !== run.tmux_session
     if (runOwnsSession) {
+      killViewerSessions(driver, run.tmux_session)
       try {
         driver.tmux(['kill-session', '-t', `=${run.tmux_session}`])
       } catch {
@@ -658,9 +685,14 @@ export function stopRun(runId: string, options: RuntimeOptions = {}): RunRecord 
   const endedAt = nowIso()
   // Only kill the run's tmux session when it differs from the reeves TUI session; a shared one would close the TUI.
   const runOwnsSession = !!run.reeves_session && run.reeves_session !== run.tmux_session
+  // Escalation below is gated on a fresh kill succeeding; if the session/window
+  // was already gone the recorded pane_pid may name a reused stranger process.
+  let sessionKilled = false
   if (runOwnsSession) {
+    killViewerSessions(driver, run.tmux_session)
     try {
       driver.tmux(['kill-session', '-t', `=${run.tmux_session}`])
+      sessionKilled = true
     } catch {
       // session may already be gone
     }
@@ -673,7 +705,11 @@ export function stopRun(runId: string, options: RuntimeOptions = {}): RunRecord 
       } catch {
         // window may already be gone
       }
+      reapPaneProcess(agent.pane_pid)
+    } else if (sessionKilled) {
+      reapPaneProcess(agent.pane_pid)
     }
+    lastPasteAtByPane.delete(agent.tmux_pane_id)
     updateAgent(run.id, agent.id, { ended_at: endedAt })
   }
   const endedRun: RunRecord = { ...run, status: 'ended', ended_at: endedAt }

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -135,6 +135,26 @@ export function killSession(session: string): void {
   }
 }
 
+// All window ids across the server in one call, keyed "session\0windowId", for
+// batch membership checks. Callers must confirm a miss with a fresh targetExists
+// probe before acting on it: a window born after the enumeration is invisible here.
+export function allWindowIds(): Set<string> {
+  try {
+    return new Set(
+      execFileSync('tmux', ['list-windows', '-a', '-F', '#{session_name}\t#{window_id}'], { encoding: 'utf8' })
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+        .map(row => {
+          const [session = '', id = ''] = row.split('\t')
+          return `${session}\0${id}`
+        }),
+    )
+  } catch {
+    return new Set()
+  }
+}
+
 export const RUN_SESSION_PATTERN = /^reeves-.+-[0-9a-f]{8}$/
 export const VIEWER_SESSION_PATTERN = /^reevesweb_[0-9a-f]{8}$/
 

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -86,6 +86,72 @@ export function targetExists(target: string, session: string): boolean {
   }
 }
 
+export interface TmuxSessionInfo {
+  name: string
+  attached: boolean
+  group: string
+  groupList: string[]
+  createdSec: number
+}
+
+// One enumeration call for the orphan sweep; a missing tmux server yields [].
+export function listSessions(): TmuxSessionInfo[] {
+  try {
+    return execFileSync('tmux', ['list-sessions', '-F', '#{session_name}\t#{session_attached}\t#{session_group}\t#{session_group_list}\t#{session_created}'], { encoding: 'utf8' })
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(row => {
+        const [name = '', attached = '0', group = '', groupList = '', created = '0'] = row.split('\t')
+        return {
+          name,
+          attached: attached !== '0',
+          group,
+          groupList: groupList.split(',').filter(Boolean),
+          createdSec: Number.parseInt(created, 10) || 0,
+        }
+      })
+  } catch {
+    return []
+  }
+}
+
+// Fresh attached-state probe for one session; the orphan sweep re-checks right
+// before killing so a human who attached since the enumeration keeps the session.
+export function sessionAttached(session: string): boolean {
+  try {
+    const out = execFileSync('tmux', ['display-message', '-p', '-t', exactSession(session), '#{session_attached}'], { encoding: 'utf8' }).trim()
+    return out !== '0' && out !== ''
+  } catch {
+    return true // cannot probe: treat as attached, never kill blind
+  }
+}
+
+export function killSession(session: string): void {
+  try {
+    spawnSync('tmux', ['kill-session', '-t', exactSession(session)], { stdio: 'ignore' })
+  } catch {
+    // session already gone
+  }
+}
+
+export const RUN_SESSION_PATTERN = /^reeves-.+-[0-9a-f]{8}$/
+export const VIEWER_SESSION_PATTERN = /^reevesweb_[0-9a-f]{8}$/
+
+// Viewer sessions (reevesweb_*) are grouped with their run session; killing one
+// group member leaves the others alive, so run teardown must kill them too.
+export function sessionInGroup(info: { group: string; groupList: string[] }, runSession: string): boolean {
+  return info.group === runSession || info.groupList.includes(runSession)
+}
+
+export function killGroupedViewers(runSession: string): void {
+  for (const info of listSessions()) {
+    if (VIEWER_SESSION_PATTERN.test(info.name) && sessionInGroup(info, runSession)) {
+      killSession(info.name)
+    }
+  }
+}
+
 export function windowIds(session: string): string[] {
   try {
     return execFileSync('tmux', ['list-windows', '-t', exactSession(session), '-F', '#{window_id}'], { encoding: 'utf8' })

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -73,6 +73,7 @@ export interface AgentRecord {
   tmux_session: string
   tmux_window_id: string
   tmux_pane_id: string
+  pane_pid?: number | null  // pane's foreground pid at spawn, for SIGTERM/SIGKILL escalation
   rc_enabled: boolean
   permissions: Permissions
   headless?: boolean        // true for add-on caller records with no tmux window

--- a/src/surfaces/cli/run.ts
+++ b/src/surfaces/cli/run.ts
@@ -16,7 +16,7 @@ import {
   computeRunStatus,
   runHasLiveTmuxTarget,
 } from '../../core/runs.js'
-import { sweepAgents } from '../../core/reaper.js'
+import { sweepAgents, sweepOrphanSessions } from '../../core/reaper.js'
 import { providerDisplayName } from '../../utils/display.js'
 import { resolveRun, resolveAgent, requireDestructiveConfirmation } from './helpers.js'
 import type { AgentRecord, AuthMode, Effort, Provider, RunRecord } from '../../core/types.js'
@@ -335,22 +335,26 @@ export function registerRuns(program: Command): void {
 export function registerReap(program: Command): void {
   program
     .command('reap')
-    .description('reap zombie agents: end any whose tmux window is gone or that outlive max_lifetime_ms')
-    .option('--json', 'output JSON array of reaped agents')
+    .description('reap zombie agents and orphan tmux sessions no live record owns')
+    .option('--json', 'output JSON object: { reaped, killed_sessions }')
     .action((opts) => {
       const { reaped } = sweepAgents()
+      const { killed } = sweepOrphanSessions({ ignoreGrace: true })
       if (opts.json) {
-        console.log(JSON.stringify(reaped, null, 2))
-        return
-      }
-      if (reaped.length === 0) {
-        console.log('no zombie agents')
+        console.log(JSON.stringify({ reaped, killed_sessions: killed }, null, 2))
         return
       }
       for (const r of reaped) {
         console.log(`${r.agent_id.slice(0, 8)}  ${r.run_id.slice(0, 8)}  ${r.reason.padEnd(17)}  ${String(Math.round(r.age_ms / 1000)).padStart(5)}s  ${r.nickname}`)
       }
-      console.log(`reaped ${reaped.length} ${reaped.length === 1 ? 'agent' : 'agents'}`)
+      for (const name of killed) {
+        console.log(`killed orphan session ${name}`)
+      }
+      if (reaped.length === 0 && killed.length === 0) {
+        console.log('no zombie agents or orphan sessions')
+        return
+      }
+      console.log(`reaped ${reaped.length} ${reaped.length === 1 ? 'agent' : 'agents'}, killed ${killed.length} orphan ${killed.length === 1 ? 'session' : 'sessions'}`)
     })
 }
 

--- a/src/surfaces/mcp/server.ts
+++ b/src/surfaces/mcp/server.ts
@@ -50,7 +50,7 @@ import {
 } from '../../core/runs.js'
 import { detectAvailable, isProvider, coerceExtraArgs } from '../../core/providers.js'
 import { PROVIDER_DEFS } from '../../core/provider-registry.js'
-import { sweepAgents, sweepAgentsThrottled } from '../../core/reaper.js'
+import { sweepAgents, sweepAgentsThrottled, sweepOrphanSessions, sweepOrphanSessionsThrottled } from '../../core/reaper.js'
 import { runDoctor } from '../../core/doctor.js'
 import { hostStatus, attach, attachAll, detach } from './installer.js'
 import { installSkills, skillsStatus } from '../../core/skills.js'
@@ -332,6 +332,7 @@ const TOOLS: ToolDef[] = [
       // Opportunistically reap zombies before listing so a dead-window agent does
       // not linger in the results. Throttled, so a chatty caller cannot spam sweeps.
       sweepAgentsThrottled()
+      sweepOrphanSessionsThrottled()
       return ok(listRuns().map(run => ({ ...run, agents: listAgents(run.id) })))
     },
   },
@@ -485,9 +486,9 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'reap',
-    description: 'Sweep for zombie agents and end them: any whose tmux window has died, plus any older than max_lifetime_ms when that is set above 0 (see get_config). Returns each reaped agent with the reason (window-gone or lifetime-exceeded) and its age. This runs on its own in the background; call it to force an immediate sweep, e.g. after a crash or before relying on list.',
+    description: 'Sweep for zombie agents and orphan tmux sessions: ends any agent whose tmux window has died or that is older than max_lifetime_ms when that is set above 0 (see get_config), and kills reeves-*/reevesweb_* sessions no live record owns. Returns each reaped agent with the reason (window-gone or lifetime-exceeded) and its age, plus the killed orphan session names. This runs on its own in the background; call it to force an immediate sweep, e.g. after a crash or before relying on list.',
     inputSchema: { type: 'object', properties: {} },
-    handler: () => ok(sweepAgents()),
+    handler: () => ok({ ...sweepAgents(), killed_sessions: sweepOrphanSessions({ ignoreGrace: true }).killed }),
   },
   {
     name: 'get_config',
@@ -726,6 +727,7 @@ export async function startAgentMcpServer(): Promise<void> {
   // it only fires while the server is already running for other reasons.
   const reapTimer = setInterval(() => {
     try { sweepAgents() } catch { /* best effort; next tick retries */ }
+    try { sweepOrphanSessions() } catch { /* best effort; next tick retries */ }
   }, BACKGROUND_REAP_INTERVAL_MS)
   reapTimer.unref()
 

--- a/src/surfaces/tui/screens/Runs.tsx
+++ b/src/surfaces/tui/screens/Runs.tsx
@@ -16,7 +16,7 @@ import { colors } from '../utils/tokens.js'
 import { glyphs } from '../utils/glyphs.js'
 import { modelBadgeLabel, modelColor, providerColor, providerDisplayName } from '../../../utils/display.js'
 import { autoCleanupRuns, computeRunStatus, listAgents, listRuns, runHasLiveTmuxTarget } from '../../../core/runs.js'
-import { sweepAgentsThrottled } from '../../../core/reaper.js'
+import { sweepAgentsThrottled, sweepOrphanSessionsThrottled } from '../../../core/reaper.js'
 import type { RunRecord } from '../../../core/types.js'
 
 const ACTIONS = ['NewRun', 'History', 'Main Menu', 'Quit'] as const
@@ -78,6 +78,7 @@ export function Runs() {
     // Reap zombie agents (dead window or past max_lifetime_ms) before archiving
     // stale runs. Throttled internally, so this fast tick stays cheap.
     sweepAgentsThrottled()
+    sweepOrphanSessionsThrottled()
     autoCleanupRuns()
     const next = listRuns()
     setRuns(prev => {

--- a/src/surfaces/webui/bridge.ts
+++ b/src/surfaces/webui/bridge.ts
@@ -73,7 +73,7 @@ function send(ws: WebSocket, frame: Record<string, unknown>): void {
 function disposeBridge(bridge: Bridge): void {
   try { bridge.term.kill() } catch { /* already exited */ }
   try {
-    execFileSync('tmux', ['kill-session', '-t', bridge.viewer], { stdio: 'ignore' })
+    execFileSync('tmux', ['kill-session', '-t', `=${bridge.viewer}`], { stdio: 'ignore' })
   } catch {
     // viewer session already gone; the shared provider window is untouched
   }
@@ -113,7 +113,7 @@ function openBridge(ws: WebSocket, id: string, bridges: Set<Bridge>): void {
     execFileSync('tmux', ['new-session', '-d', '-s', viewer, '-t', `=${target.session}`], { stdio: 'ignore' })
     execFileSync('tmux', ['select-window', '-t', `${viewer}:${target.windowId}`], { stdio: 'ignore' })
   } catch {
-    try { execFileSync('tmux', ['kill-session', '-t', viewer], { stdio: 'ignore' }) } catch { /* nothing to clean */ }
+    try { execFileSync('tmux', ['kill-session', '-t', `=${viewer}`], { stdio: 'ignore' }) } catch { /* nothing to clean */ }
     send(ws, { t: 'e', m: 'could not open a tmux view for this agent' })
     ws.close()
     return

--- a/src/surfaces/webui/server.ts
+++ b/src/surfaces/webui/server.ts
@@ -31,6 +31,7 @@ import {
   listRunHistory,
   readRun,
 } from '../../core/runs.js'
+import { sweepAgentsThrottled, sweepOrphanSessionsThrottled } from '../../core/reaper.js'
 import { resolveRunApproval } from '../../core/approvals.js'
 import { runDoctor } from '../../core/doctor.js'
 import { REEVESAGENTS_VERSION } from '../../version.js'
@@ -150,7 +151,11 @@ function createSseHub(): SseHub {
   let last = ''
 
   const snapshot = (): string => {
-    autoCleanupRuns({ cleanStale: false })
+    // Web-only users get the same zombie/orphan reaping and stale cleanup the TUI
+    // tick performs; both sweeps are throttled internally, so this stays cheap.
+    sweepAgentsThrottled()
+    sweepOrphanSessionsThrottled()
+    autoCleanupRuns()
     return JSON.stringify(buildWebState())
   }
   const write = (res: ServerResponse, payload: string): void => {
@@ -432,7 +437,9 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, ctx: Req
     return
   }
   if (method === 'GET' && path === '/api/state') {
-    autoCleanupRuns({ cleanStale: false })
+    sweepAgentsThrottled()
+    sweepOrphanSessionsThrottled()
+    autoCleanupRuns()
     sendJson(res, 200, {
       ...buildWebState(),
       providers: listWebProviders(),

--- a/test/reaper.test.ts
+++ b/test/reaper.test.ts
@@ -5,7 +5,13 @@ import { tmpdir } from 'node:os'
 import type { AgentRecord, RunRecord } from '../src/core/types.js'
 import type { RuntimeDriver } from '../src/core/runtime.js'
 import { writeRun, writeAgent, listAgents } from '../src/core/runs.js'
-import { sweepAgents, sweepAgentsThrottled, resetSweepThrottle } from '../src/core/reaper.js'
+import {
+  sweepAgents,
+  sweepAgentsThrottled,
+  sweepOrphanSessions,
+  resetSweepThrottle,
+} from '../src/core/reaper.js'
+import type { TmuxSessionInfo } from '../src/core/tmux.js'
 
 let tmpDir: string
 let savedTmux: string | undefined
@@ -181,5 +187,93 @@ describe('zombie-agent reaper', () => {
     expect(b.swept).toBe(false)
     const c = sweepAgentsThrottled(15_000, { ...opts, now: () => 20_000 })
     expect(c.swept).toBe(true)
+  })
+})
+
+describe('orphan session sweep', () => {
+  function session(name: string, overrides: Partial<TmuxSessionInfo> = {}): TmuxSessionInfo {
+    // createdSec 0 reads as "unknown age", which is always old enough to reap.
+    return { name, attached: false, group: '', groupList: [], createdSec: 0, ...overrides }
+  }
+
+  function runSweep(sessions: TmuxSessionInfo[], extra: { sessionAttached?: (_name: string) => boolean; now?: () => number } = {}): { killed: string[]; calls: string[] } {
+    const calls: string[] = []
+    const { killed } = sweepOrphanSessions({
+      listSessions: () => sessions,
+      killSession: name => calls.push(name),
+      sessionAttached: () => false,
+      ...extra,
+    })
+    return { killed, calls }
+  }
+
+  it('kills a run session no live record owns', () => {
+    const { killed, calls } = runSweep([session('reeves-crashed-a1b2c3d4')])
+    expect(killed).toEqual(['reeves-crashed-a1b2c3d4'])
+    expect(calls).toEqual(['reeves-crashed-a1b2c3d4'])
+  })
+
+  it('spares a run session with a live record', () => {
+    writeRun(makeRun('r1'))
+    // makeRun's tmux_session does not match the run-session pattern, so use a
+    // record whose session name does.
+    const run = makeRun('r2')
+    run.tmux_session = 'reeves-live-b2c3d4e5'
+    writeRun(run)
+
+    const { killed } = runSweep([
+      session('reeves-live-b2c3d4e5'),
+      session('reeves-crashed-a1b2c3d4'),
+    ])
+    expect(killed).toEqual(['reeves-crashed-a1b2c3d4'])
+  })
+
+  it('spares sessions a human is attached to', () => {
+    const { killed } = runSweep([session('reeves-watched-a1b2c3d4', { attached: true })])
+    expect(killed).toEqual([])
+  })
+
+  it('kills a viewer whose group holds no live run session, spares a backed one', () => {
+    const run = makeRun('r3')
+    run.tmux_session = 'reeves-backed-c3d4e5f6'
+    writeRun(run)
+
+    const { killed } = runSweep([
+      session('reevesweb_11111111', { group: 'reeves-backed-c3d4e5f6', groupList: ['reeves-backed-c3d4e5f6', 'reevesweb_11111111'] }),
+      session('reevesweb_22222222', { group: 'reeves-gone-d4e5f6a1', groupList: ['reeves-gone-d4e5f6a1', 'reevesweb_22222222'] }),
+      session('reevesweb_33333333'),
+    ])
+    expect(killed).toEqual(['reevesweb_22222222', 'reevesweb_33333333'])
+  })
+
+  it('ignores sessions outside the reeves naming patterns', () => {
+    const { killed } = runSweep([
+      session('reeves'),
+      session('reeves-not-a-run-id'),
+      session('other-session'),
+    ])
+    expect(killed).toEqual([])
+  })
+
+  it('kills nothing when tmux is unavailable', () => {
+    const { killed } = sweepOrphanSessions({ tmuxAvailable: () => false })
+    expect(killed).toEqual([])
+  })
+
+  it('spares sessions younger than the orphan grace period (a run still starting)', () => {
+    const nowMs = 1_000_000_000_000
+    const justBorn = Math.floor(nowMs / 1000) - 5
+    const { killed } = runSweep(
+      [session('reeves-starting-a1b2c3d4', { createdSec: justBorn }), session('reeves-old-b2c3d4e5', { createdSec: justBorn - 3600 })],
+      { now: () => nowMs },
+    )
+    expect(killed).toEqual(['reeves-old-b2c3d4e5'])
+  })
+
+  it('re-probes attached state right before killing', () => {
+    // Enumeration said unattached, but a human attached before the kill landed.
+    const { killed, calls } = runSweep([session('reeves-grabbed-a1b2c3d4')], { sessionAttached: () => true })
+    expect(killed).toEqual([])
+    expect(calls).toEqual([])
   })
 })

--- a/test/runs-state.test.ts
+++ b/test/runs-state.test.ts
@@ -129,16 +129,15 @@ describe('v1 run state', () => {
     expect(readAgent('headless', 'root').headless).toBe(true)
   })
 
-  it('updates and heartbeats agents', async () => {
-    const { writeRun, writeAgent, updateAgent, heartbeatAgent, readAgent } = await import('../src/core/runs.js')
+  it('updates agents', async () => {
+    const { writeRun, writeAgent, updateAgent, readAgent } = await import('../src/core/runs.js')
     writeRun(makeRun('r6'))
     writeAgent(makeAgent('a1', 'r6', { last_seen: 1 }))
     updateAgent('r6', 'a1', { task_status: 'working', task_note: 'running tests' })
-    heartbeatAgent('r6', 'a1')
     const agent = readAgent('r6', 'a1')
     expect(agent.task_status).toBe('working')
     expect(agent.task_note).toBe('running tests')
-    expect(agent.last_seen).toBeGreaterThan(1)
+    expect(agent.last_seen).toBe(1)
   })
 
   it('redacts agent task, note, and inbox message text before writing', async () => {
@@ -318,6 +317,78 @@ describe('v1 run state', () => {
 
       expect(result.removed).toContain('window-stale')
       expect(existsSync(join(tmpDir, 'runs', 'window-stale'))).toBe(false)
+    })
+
+    it('kills the pinned run session and its viewers before archiving a stale run', async () => {
+      const { writeRun, writeAgent, autoCleanupRuns, listRunHistory } = await import('../src/core/runs.js')
+      writeRun(makeRun('pinned', { root_agent_id: 'root' }))
+      writeAgent(makeAgent('root', 'pinned', { role: 'root', tmux_window_id: '@dead', tmux_pane_id: '%dead' }))
+
+      const calls: string[] = []
+      const result = autoCleanupRuns({
+        sessionExists: () => true,
+        targetExists: () => false,
+        killViewers: session => calls.push(`viewers:${session}`),
+        killSession: session => calls.push(`session:${session}`),
+      })
+
+      expect(result.removed).toContain('pinned')
+      expect(listRunHistory()[0]?.status).toBe('stale')
+      // Viewers die before the run session so neither keeps the other's windows alive.
+      expect(calls).toEqual([`viewers:${'reeves_pinned'}`, `session:${'reeves_pinned'}`])
+    })
+
+    it('does not kill sessions for ended runs (their teardown already ran)', async () => {
+      const { writeRun, autoCleanupRuns } = await import('../src/core/runs.js')
+      writeRun(makeRun('ended-run', { status: 'ended', ended_at: '2026-01-01T00:00:01.000Z' }))
+
+      const calls: string[] = []
+      const result = autoCleanupRuns({
+        sessionExists: () => true,
+        killViewers: session => calls.push(`viewers:${session}`),
+        killSession: session => calls.push(`session:${session}`),
+      })
+
+      expect(result.removed).toContain('ended-run')
+      expect(calls).toEqual([])
+    })
+
+    it('archives a stale run whose session is gone, still sweeping its viewers', async () => {
+      const { writeRun, autoCleanupRuns } = await import('../src/core/runs.js')
+      writeRun(makeRun('gone-run'))
+
+      const calls: string[] = []
+      const result = autoCleanupRuns({
+        sessionExists: () => false,
+        killViewers: session => calls.push(`viewers:${session}`),
+        killSession: session => calls.push(`session:${session}`),
+      })
+
+      expect(result.removed).toContain('gone-run')
+      // The run session is already dead, but grouped viewers can outlive it and
+      // stay identifiable by group name, so the viewer sweep runs regardless.
+      expect(calls).toEqual(['viewers:reeves_gone-run'])
+    })
+
+    it('escalates stubborn pane processes when archiving a stale run', async () => {
+      const { writeRun, writeAgent, autoCleanupRuns } = await import('../src/core/runs.js')
+      const { spawn } = await import('node:child_process')
+      writeRun(makeRun('stubborn-run', { root_agent_id: 'root' }))
+      // A SIGHUP/SIGTERM-ignoring CLI: only the SIGKILL escalation can end it.
+      const child = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); process.on("SIGHUP", () => {}); setInterval(() => {}, 1000)'])
+      const exited = new Promise<string>(resolve => child.once('exit', () => resolve('exited')))
+      writeAgent(makeAgent('root', 'stubborn-run', { role: 'root', tmux_window_id: '@dead', tmux_pane_id: '%dead', pane_pid: child.pid }))
+
+      const result = autoCleanupRuns({
+        sessionExists: () => true,
+        targetExists: () => false,
+        killViewers: () => {},
+        killSession: () => {},
+      })
+
+      expect(result.removed).toContain('stubborn-run')
+      const timeout = new Promise<string>(resolve => setTimeout(() => resolve('alive'), 3000))
+      expect(await Promise.race([exited, timeout])).toBe('exited')
     })
 
     it('cleans only dead and keeps live ones in a mixed registry', async () => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -38,6 +38,8 @@ class FakeDriver implements RuntimeDriver {
   windows = new Set<string>(['@0'])
   panes = new Set<string>(['%0'])
   captureOutput = '\u001b[31mready\u001b[0m sk-ant-api03-abcdefghij1234567890abcdef'
+  // Rows returned for list-sessions (tab-separated name, group, group list).
+  sessionRows: string[] = []
 
   tmux(args: string[], input?: string): string {
     this.calls.push(input === undefined ? { args } : { args, input })
@@ -50,6 +52,7 @@ class FakeDriver implements RuntimeDriver {
     }
     if (args[0] === 'list-windows') return [...this.windows].join('\n')
     if (args[0] === 'list-panes') return [...this.panes].join('\n')
+    if (args[0] === 'list-sessions') return this.sessionRows.join('\n')
     if (args[0] === 'kill-window') {
       const target = args[args.indexOf('-t') + 1] ?? ''
       this.windows.delete(target)
@@ -69,7 +72,9 @@ class FakeDriver implements RuntimeDriver {
 describe('agent-run runtime', () => {
   it('parses stable tmux window and pane ids', async () => {
     const { parseTmuxIds } = await import('../src/core/runtime.js')
-    expect(parseTmuxIds('@12 %34')).toEqual({ windowId: '@12', paneId: '%34' })
+    expect(parseTmuxIds('@12 %34')).toEqual({ windowId: '@12', paneId: '%34', panePid: undefined })
+    expect(parseTmuxIds('@12 %34 567')).toEqual({ windowId: '@12', paneId: '%34', panePid: 567 })
+    expect(parseTmuxIds('@12 %34 notapid').panePid).toBeUndefined()
     expect(() => parseTmuxIds('0 1')).toThrow(/Could not parse/)
   })
 
@@ -306,5 +311,120 @@ describe('agent-run runtime', () => {
     const target = anchor!.args[anchor!.args.indexOf('-t') + 1]
     expect(target).toBe('reeves:')
     expect(target).not.toBe('reeves')
+  })
+
+  it('escalates to SIGKILL when the pane process ignores SIGHUP and SIGTERM', async () => {
+    const driver = new FakeDriver()
+    const { startRun, killAgent } = await import('../src/core/runtime.js')
+    const { updateAgent } = await import('../src/core/runs.js')
+    const { spawn } = await import('node:child_process')
+
+    const result = startRun({
+      name: 'stubborn',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const agent = result.agents[0]!
+
+    // Stand in for an agent CLI that traps every polite signal.
+    const child = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); process.on("SIGHUP", () => {}); setInterval(() => {}, 1000)'])
+    // A killed child stays visible to kill(pid, 0) as a zombie until its exit is
+    // consumed, so assert on the exit event, not on signal-0 liveness.
+    const exited = new Promise<void>(resolve => child.once('exit', () => resolve()))
+    updateAgent(result.run.id, agent.id, { pane_pid: child.pid })
+
+    killAgent(agent.id, { driver })
+
+    const timeout = new Promise<null>(resolve => setTimeout(() => resolve(null), 3000))
+    expect(await Promise.race([exited.then(() => 'exited' as const), timeout])).toBe('exited')
+    expect(child.exitCode).toBeNull() // signal death, not a clean exit
+  })
+
+  it('leaves the pane process alone when it already exited with its window', async () => {
+    const driver = new FakeDriver()
+    const { startRun, killAgent } = await import('../src/core/runtime.js')
+    const { updateAgent } = await import('../src/core/runs.js')
+
+    const result = startRun({
+      name: 'gone',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const agent = result.agents[0]!
+    // A pid that does not exist: escalation must be a no-op, not an error.
+    updateAgent(result.run.id, agent.id, { pane_pid: 2_000_000_000 })
+    expect(killAgent(agent.id, { driver }).ended_at).not.toBeNull()
+  })
+
+  it('never signals the pane process when the stored window id is stale', async () => {
+    const driver = new FakeDriver()
+    const { startRun, killAgent } = await import('../src/core/runtime.js')
+    const { updateAgent } = await import('../src/core/runs.js')
+    const { spawn } = await import('node:child_process')
+
+    const result = startRun({
+      name: 'stale-pid',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const agent = result.agents[0]!
+
+    // After a tmux server restart the recorded ids are untrusted; the pane_pid
+    // may by now name a reused, unrelated process, which must survive killAgent.
+    driver.windows.delete(agent.tmux_window_id)
+    driver.panes.delete(agent.tmux_pane_id)
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'])
+    const exited = new Promise<string>(resolve => child.once('exit', () => resolve('exited')))
+    updateAgent(result.run.id, agent.id, { pane_pid: child.pid })
+
+    killAgent(agent.id, { driver })
+
+    const tick = new Promise<string>(resolve => setTimeout(() => resolve('alive'), 1200))
+    expect(await Promise.race([exited, tick])).toBe('alive')
+    child.kill('SIGKILL')
+  })
+
+  it('stopRun kills grouped web viewer sessions before the run session', async () => {
+    const driver = new FakeDriver()
+    const { startRun, stopRun } = await import('../src/core/runtime.js')
+
+    const result = startRun({
+      name: 'viewed',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const runSession = result.run.tmux_session
+    driver.sessionRows = [
+      `reevesweb_abcd1234\t${runSession}\t${runSession},reevesweb_abcd1234`,
+      'reevesweb_deadbeef\treeves-other-12345678\treeves-other-12345678,reevesweb_deadbeef',
+      'unrelated\t\t',
+    ]
+
+    stopRun(result.run.id, { driver })
+
+    const killSessions = driver.calls.filter(call => call.args[0] === 'kill-session').map(call => call.args.at(-1))
+    expect(killSessions).toContain('=reevesweb_abcd1234')
+    expect(killSessions).toContain(`=${runSession}`)
+    expect(killSessions).not.toContain('=reevesweb_deadbeef')
+    expect(killSessions.indexOf('=reevesweb_abcd1234')).toBeLessThan(killSessions.indexOf(`=${runSession}`))
+  })
+
+  it('killAgent kills grouped viewers when the last agent ends', async () => {
+    const driver = new FakeDriver()
+    const { startRun, killAgent } = await import('../src/core/runtime.js')
+
+    const result = startRun({
+      name: 'viewed-solo',
+      working_dir: '/tmp',
+      root: { provider: 'codex', model: '', task: 'lead', nickname: 'first' },
+    }, { driver, available })
+    const runSession = result.run.tmux_session
+    driver.sessionRows = [`reevesweb_0badf00d\t${runSession}\t${runSession},reevesweb_0badf00d`]
+
+    killAgent(result.agents[0]!.id, { driver })
+
+    const killSessions = driver.calls.filter(call => call.args[0] === 'kill-session').map(call => call.args.at(-1))
+    expect(killSessions).toContain('=reevesweb_0badf00d')
+    expect(killSessions).toContain(`=${runSession}`)
   })
 })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -13,13 +13,30 @@ const englishConfig = JSON.stringify({ version: 2, global: { language: 'en' } })
 // need a specific home still override REEVES_HOME themselves.
 const homeRoot = mkdtempSync(join(tmpdir(), 'reeves-vitest-home-'))
 
+// Point tmux at an isolated, always-empty server. Any code path that forgets its
+// driver/seam injection (a real sweep from a web or MCP test) then probes and
+// "reaps" only this sandbox instead of killing the developer's live sessions.
+const tmuxRoot = mkdtempSync(join(tmpdir(), 'reeves-vitest-tmux-'))
+
+// Same for the run registry: stateRoot() reads REEVES_REGISTRY, not REEVES_HOME,
+// so a test that forgets to set it would otherwise sweep and archive the
+// developer's real ~/.reeves runs.
+const registryRoot = mkdtempSync(join(tmpdir(), 'reeves-vitest-registry-'))
+
 beforeEach(() => {
   writeFileSync(configPath, englishConfig, 'utf8')
   process.env.REEVES_CONFIG = configPath
   process.env.REEVES_HOME = homeRoot
+  process.env.REEVES_REGISTRY = registryRoot
+  process.env.TMUX_TMPDIR = tmuxRoot
+  // An inherited TMUX (test runner inside tmux) beats TMUX_TMPDIR for socket
+  // selection, so it must go or the isolation above is an illusion.
+  delete process.env.TMUX
 })
 
 afterAll(() => {
   rmSync(configRoot, { recursive: true, force: true })
   rmSync(homeRoot, { recursive: true, force: true })
+  rmSync(tmuxRoot, { recursive: true, force: true })
+  rmSync(registryRoot, { recursive: true, force: true })
 })

--- a/test/web/server-actions.test.ts
+++ b/test/web/server-actions.test.ts
@@ -480,6 +480,9 @@ describe('approvals', () => {
   it('lists pending approvals in state and resolves one through HTTP', async () => {
     const { createRunApproval, listRunApprovals } = await import('../../src/core/approvals.js')
 
+    // /api/state now sweeps zombies and archives stale runs, so the run behind
+    // the approval must look alive: fake tmux reports its window ids as present.
+    installFakeRuntimeBins()
     writeRun(makeRun('appr-run'))
     writeAgent(makeAgent('appr-agent', 'appr-run', 'cc', 'root'))
     const approval = createRunApproval({


### PR DESCRIPTION
## Problem

Old processes and tmux sessions were never really killed: cleanup removed run/agent records without touching tmux, so sessions pinned open by the linked `reeves` tab, grouped web viewer sessions, and SIGHUP-resistant agent processes accumulated and crushed terminals.

## Root causes fixed

- `autoCleanupRuns` archived stale runs without a single tmux kill (#48)
- `stopRun`/`killAgent` never touched grouped `reevesweb_*` viewers; killing one group member leaves the others (and every window/process they hold) alive (#49)
- teardown was SIGHUP-only: no pid tracking, no SIGTERM/SIGKILL escalation (#50)
- no orphan enumeration: crash-between-create-and-write sessions and deleted-state sessions were invisible forever (#51)
- the web UI never swept zombies or stale runs at all; `disposeBridge` used a non-exact session target; `heartbeatAgent` was dead code; `lastPasteAtByPane` grew unboundedly (#52)

## What changed

**fix(core)** — the pane pid is recorded at spawn; teardown kills grouped viewers, then the session/window, then escalates SIGTERM → SIGKILL on the pane process group. Escalation is gated on a fresh tmux confirmation that the window was really ours (a stale `pane_pid` can be a reused pid). `autoCleanupRuns` kills viewers + session + stubborn pane processes before archiving. New `sweepOrphanSessions` reaps sessions no record owns, sparing attached sessions (re-probed right before the kill) and sessions younger than a 60s grace (a run still starting in another process); wired into the TUI tick, MCP list/reap/background sweep, CLI `reap` (manual reap bypasses the grace), and the web state paths.

**perf(core)** — sweep probes are batched into one server-wide `list-windows -a` enumeration per sweep instead of a tmux spawn per agent per run; a batched miss is always confirmed with a fresh probe before anything is killed. Refs #53.

**test(setup)** — tests now run against an isolated tmux server (`TMUX_TMPDIR` + clearing inherited `TMUX`) and a throwaway `REEVES_REGISTRY`, so an unseamed sweep in a web/MCP test can never kill the developer's live sessions or archive real runs. (This actually happened during development: a codex review agent's own vitest run reaped its own tmux session.)

## Verification

- `pnpm verify:release` green: typecheck, lint, 742 tests (15 new), build, CLI smoke, package contents, install matrix
- Real-tmux e2e on macOS (isolated tmux server, stub provider CLIs): kill-agent teardown, stop-run with grouped viewer, orphan reap, pinned stale session cleanup, SIGKILL escalation for a SIGHUP/SIGTERM-trapping agent — 15/15 checks pass
- Cross-reviewed by a codex agent (spawned via the installed reevesagents, dogfooding the spawn/kill path): 3 P1 + 2 P2 findings (start-window race, pid-reuse escalation risk, `TMUX` inheritance defeating test isolation, pre-archive escalation gap, viewer sweep gap) — all fixed in this branch; its false alarms (batching races, viewer kill ordering, group-format assumptions) were verified against real tmux

## Notes

- `reevesagents reap --json` output changed from an array to `{ reaped, killed_sessions }` (help text updated)
- Orphan ownership is judged against the current registry only; two `REEVES_REGISTRY` roots sharing one tmux server is unsupported (documented in `sweepOrphanSessions`)

Closes #48
Closes #49
Closes #50
Closes #51
Closes #52